### PR TITLE
feat: add slide format reference and create-presentation skill

### DIFF
--- a/.claude/commands/create-presentation.md
+++ b/.claude/commands/create-presentation.md
@@ -1,0 +1,83 @@
+---
+description: "Create a new slide deck presentation. Use when asked to make, create, write, or author a presentation, slide deck, talk, or slides."
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep
+---
+
+Create a new Marko Pollo slide deck.
+
+## Format Reference
+
+**REQUIRED:** Before writing any slides, read the format specification:
+
+```
+presentations/FORMAT.md
+```
+
+This file documents every available feature — frontmatter, slide metadata, code annotations, Mermaid diagrams, GFM tables, emoji shortcodes, and more. Use it as your reference throughout.
+
+## Arguments
+
+Parse `$ARGUMENTS` to extract:
+- **Topic or title** (optional): What the presentation is about
+- **`--name <dir-name>`** (optional): Directory name under `presentations/` (defaults to kebab-case of title)
+
+If no arguments are provided, ask the user what the presentation should cover.
+
+## Steps
+
+1. **Read the format spec:** Read `presentations/FORMAT.md` to load the full slide format reference.
+
+2. **Clarify scope:** If the topic is broad, ask the user:
+   - How many slides (rough target)?
+   - Audience level (beginner, intermediate, advanced)?
+   - Any specific subtopics to include or exclude?
+   - Should it include code examples, diagrams, or both?
+
+3. **Plan the outline:** Before writing slides, propose a short outline (slide titles and one-line descriptions). Get user approval before proceeding.
+
+4. **Create the deck directory:**
+   ```
+   presentations/<dir-name>/slides.md
+   ```
+   The directory name becomes the deck ID and must be lowercase kebab-case.
+
+5. **Write the slides** following these guidelines:
+
+   **Structure:**
+   - Start with YAML frontmatter (`title`, `author`, `date`)
+   - Separate slides with `---` on its own line
+   - Open with a title slide (`# Title` + subtitle paragraph)
+   - Close with a summary or "Thank you" slide
+
+   **Content density:**
+   - One idea per slide — avoid walls of text
+   - Prefer bullet lists (3–5 items) over paragraphs
+   - Use headings (`##`) as slide titles for every slide
+
+   **Visual variety:** Mix content types across slides to keep the deck engaging:
+   - Code blocks with syntax highlighting and annotations (`// [!code focus]`, `// [!code ++]`)
+   - Mermaid diagrams for architecture, flows, or relationships
+   - GFM tables for comparisons or feature matrices
+   - Task lists for roadmaps or checklists
+   - Blockquotes for key takeaways
+   - Emoji shortcodes for visual accents (`:rocket:`, `:sparkles:`)
+
+   **Slide metadata:** Use `<!-- bg: #hex -->` sparingly for emphasis slides (e.g., section dividers or key takeaways). Don't override every slide.
+
+   **Code examples:**
+   - Always specify the language for syntax highlighting
+   - Use `// [!code focus]` to draw attention to key lines
+   - Use `// [!code ++]` / `// [!code --]` for before/after comparisons
+   - Keep code blocks short (under 15 lines per slide)
+
+6. **Verify the deck:** After writing, confirm:
+   - Frontmatter has `title` and `author`
+   - Every slide has a `##` heading (except the title slide which uses `#`)
+   - Slide separators (`---`) are on their own line with blank lines around them
+   - Code blocks specify a language
+   - No slide has more than ~8 bullet points
+   - The deck directory name is lowercase kebab-case
+
+7. **Report:** Tell the user the deck path and how to view it (navigate to `/#deck/<dir-name>/1` in the app).
+
+Arguments: $ARGUMENTS

--- a/presentations/FORMAT.md
+++ b/presentations/FORMAT.md
@@ -1,0 +1,171 @@
+# Slide Format Reference
+
+## Document Structure
+
+```markdown
+---
+title: My Talk Title
+author: Jane Developer
+date: 2026-02-27
+---
+
+# First Slide
+
+---
+
+# Second Slide
+```
+
+**Frontmatter** (optional) goes at the very top between `---` fences. Supported
+fields: `title`, `author`, `date`, `aspectRatio`, plus arbitrary key/value pairs.
+
+**Slide separators** — a line containing only `---`, `***`, or `___` (three or
+more characters). Blank lines around separators are optional but recommended.
+
+## Per-Slide Metadata
+
+HTML comment directives at the start of a slide set per-slide options:
+
+```markdown
+<!-- bg: #1a1a2e -->
+<!-- layout: center -->
+<!-- class: my-class -->
+<!-- transition: fade -->
+
+# Slide With Custom Background
+```
+
+| Directive | Values | Effect |
+|-----------|--------|--------|
+| `bg` | Any CSS color | Custom background color |
+| `layout` | `default`, `center`, `two-column` | Content alignment |
+| `class` | CSS class name | Extra class on the slide |
+| `transition` | `fade`, `slide`, `none` | Slide transition |
+
+## Markdown Features
+
+### Typography
+
+| Syntax | Renders As |
+|--------|-----------|
+| `# Heading` | Title — large with gold/green gradient underline |
+| `## Heading` | Subtitle — muted tan |
+| `### ` through `######` | Smaller headings |
+| `**bold**` | **Bold** — cream, weight 600 |
+| `*italic*` | *Italic* — green accent |
+| `~~strike~~` | ~~Strikethrough~~ — muted with line-through |
+| `` `code` `` | Inline code — mono font, green on dark bg |
+| `> quote` | Blockquote — gold left border, italic |
+
+### Lists
+
+```markdown
+- Unordered item          (gold bullet)
+1. Ordered item           (gold number)
+- [ ] Unchecked task      (styled checkbox)
+- [x] Completed task      (gold checkbox with checkmark)
+```
+
+### Tables (GFM)
+
+```markdown
+| Feature | Status |
+|---------|--------|
+| Auth    | Done   |
+| Export  | WIP    |
+```
+
+Tables get branded styling: gold header border, alternating row backgrounds.
+
+### Images
+
+```markdown
+![Architecture diagram](./arch.png)
+```
+
+Images are responsive with rounded corners and a box shadow.
+
+### Links
+
+```markdown
+[Docs](https://example.com)
+```
+
+URLs are also auto-linked by GFM.
+
+### Emojis
+
+Shortcodes like `:rocket:`, `:tada:`, `:sparkles:` are converted to unicode.
+
+## Code Blocks
+
+Fenced code blocks are syntax-highlighted with Shiki. Specify the language after
+the opening fence:
+
+````markdown
+```typescript
+function greet(name: string): string {
+  return `Hello, ${name}!`
+}
+```
+````
+
+**Supported languages:** typescript, javascript, tsx, jsx, python, rust, go,
+java, c, cpp, csharp, ruby, swift, kotlin, bash, shell, json, yaml, toml, html,
+css, sql, graphql, markdown, dockerfile, plaintext.
+
+### Code Annotations
+
+Add comment annotations at the end of any line inside a code block:
+
+| Annotation | Effect |
+|------------|--------|
+| `// [!code ++]` | Green diff — line added |
+| `// [!code --]` | Red diff — line removed |
+| `// [!code highlight]` | Gold highlight on the line |
+| `// [!code focus]` | Focus this line, dim all others |
+| `// [!code error]` | Red error highlight |
+| `// [!code warning]` | Gold warning highlight |
+
+**Diff example:**
+
+```typescript
+const greeting = 'hello' // [!code --]
+const greeting = 'hi'    // [!code ++]
+```
+
+**Focus example** (unfocused lines are dimmed):
+
+```typescript
+const config = loadConfig()
+const server = createServer(config) // [!code focus]
+server.listen(3000)
+```
+
+## Mermaid Diagrams
+
+Use `mermaid` as the language identifier to render diagrams. All Mermaid v11
+diagram types are supported (flowcharts, sequence, class, state, ER, gantt,
+pie, etc.). Diagrams are automatically themed to match the brand palette.
+
+````markdown
+```mermaid
+flowchart LR
+    Client --> Gateway[API Gateway]
+    Gateway --> Auth[Auth Service]
+    Gateway --> DB[(Database)]
+```
+````
+
+## Adding a New Deck
+
+Create a new directory under `presentations/` with a `slides.md` file:
+
+```
+presentations/
+  my-new-talk/
+    slides.md
+```
+
+The directory name becomes the deck ID. The deck is auto-discovered at build
+time — no registration needed.


### PR DESCRIPTION
## Summary

- Add `presentations/FORMAT.md` — documents the full slide markdown format (frontmatter, separators, per-slide metadata, code annotations, Mermaid diagrams, GFM features, emoji support)
- Add `/create-presentation` command — guides agents through authoring new slide decks, with the format spec as its first reference step

## Test plan

- [ ] Verify `/create-presentation` appears in the skills list
- [ ] Run `/create-presentation "Test Talk"` and confirm it reads FORMAT.md, proposes an outline, and writes a valid deck
- [ ] Verify FORMAT.md accurately reflects all supported features

🤖 Generated with [Claude Code](https://claude.com/claude-code)