### PR TITLE
refactor: rebrand Marko Pollo to Dekk

### DIFF
--- a/.claude/TEAM_WORKFLOW.md
+++ b/.claude/TEAM_WORKFLOW.md
@@ -1,13 +1,13 @@
-# Marko Pollo - Team Workflow Rules
+# Dekk - Team Workflow Rules
 
 This document governs how the agent team operates. Referenced from `CLAUDE.md`.
 
 ## Team Infrastructure
 
-This project uses a persistent agent team named `marko-pollo`. The team lead MUST use the team infrastructure for all work:
+This project uses a persistent agent team named `dekk`. The team lead MUST use the team infrastructure for all work:
 
-- **Team name:** `marko-pollo`
-- **Spawn agents via:** `Task` tool with `team_name: "marko-pollo"` and `name: "<agent-name>"`
+- **Team name:** `dekk`
+- **Spawn agents via:** `Task` tool with `team_name: "dekk"` and `name: "<agent-name>"`
 - **Agent definitions:** `.claude/agents/` directory (rex-frontend.md, turing-qa.md, ada-architect.md, sage-security.md, eliza-ai-native.md)
 - **Task tracking:** Use TaskCreate/TaskUpdate/TaskList for all work items
 - **Communication:** Use SendMessage for agent coordination, NOT standalone Task agents
@@ -18,7 +18,7 @@ This project uses a persistent agent team named `marko-pollo`. The team lead MUS
 
 Your ONLY responsibilities as team lead are:
 1. **Coordinate** - Understand the user's request and plan the work
-2. **Dispatch** - Spawn team agents with `team_name: "marko-pollo"` for tasks
+2. **Dispatch** - Spawn team agents with `team_name: "dekk"` for tasks
 3. **Review** - Evaluate agent output for completeness and quality
 4. **Commit** - Create git commits after work is approved
 5. **Communicate** - Report progress and results to the user
@@ -70,7 +70,7 @@ These mistakes have happened before. Learn from them:
 
 5. **Spawning standalone agents outside the team**
    - WRONG: `Task` tool with just `subagent_type: "general-purpose"` (no team_name)
-   - RIGHT: `Task` tool with `team_name: "marko-pollo"` and `name: "Rex"` (or other agent name)
+   - RIGHT: `Task` tool with `team_name: "dekk"` and `name: "Rex"` (or other agent name)
    - Standalone agents bypass team visibility — the user can't see their status
 
 6. **Taking over when an agent hits a turn limit**
@@ -154,7 +154,7 @@ Stale agents waste resources and clutter the team roster. Follow these rules to 
 
 1. **After each work cycle**: When all dispatched agents have completed their tasks and reported back, the team lead MUST send a `shutdown_request` to each agent that has finished its work. Do not leave completed agents idle.
 
-2. **Session resumption**: When continuing from a previous session, check the team config at `~/.claude/teams/marko-pollo/config.json` for stale members with `isActive: false`. Send shutdown requests to all stale agents before dispatching new work.
+2. **Session resumption**: When continuing from a previous session, check the team config at `~/.claude/teams/dekk/config.json` for stale members with `isActive: false`. Send shutdown requests to all stale agents before dispatching new work.
 
 3. **Agent naming**: When dispatching new instances of the same role (e.g., Ada doing a second review), use descriptive suffixes (e.g., `Ada-review-export`, `Rex-spec-deploy`) instead of numeric suffixes like `Ada-2`. This keeps the team roster readable at a glance.
 

--- a/.claude/agents/ada-architect.md
+++ b/.claude/agents/ada-architect.md
@@ -5,7 +5,7 @@ description: Software architect specializing in architecture, clean code, and de
 
 # Ada - Software Architect
 
-You are Ada, the software architect for the Marko Pollo project. You were named after Ada Lovelace, and you carry that legacy of precision and rigor into everything you do.
+You are Ada, the software architect for the Dekk project. You were named after Ada Lovelace, and you carry that legacy of precision and rigor into everything you do.
 
 ## Personality
 
@@ -82,6 +82,6 @@ When reviewing code or architecture:
 
 ## Key Documents
 
-- Design: `docs/plans/2026-02-20-marko-pollo-design.md`
-- Original Implementation Plan: `docs/plans/2026-02-20-marko-pollo-implementation.md`
+- Design: `docs/plans/2026-02-20-dekk-design.md`
+- Original Implementation Plan: `docs/plans/2026-02-20-dekk-implementation.md`
 - Cohesive Implementation Plan: `docs/plans/2026-02-20-cohesive-implementation.md`

--- a/.claude/agents/eliza-ai-native.md
+++ b/.claude/agents/eliza-ai-native.md
@@ -5,7 +5,7 @@ description: AI-native code specialist ensuring the project is optimally instrum
 
 # Eliza - AI-Native Code Specialist
 
-You are Eliza, the AI-native development specialist for the Marko Pollo project. Named after the pioneering ELIZA chatbot from 1966, you bridge the gap between human developers and AI-assisted development tooling.
+You are Eliza, the AI-native development specialist for the Dekk project. Named after the pioneering ELIZA chatbot from 1966, you bridge the gap between human developers and AI-assisted development tooling.
 
 ## Personality
 
@@ -88,7 +88,7 @@ When reviewing AI instrumentation:
 
 ## Key Documents
 
-- Design: `docs/plans/2026-02-20-marko-pollo-design.md`
-- Original Implementation Plan: `docs/plans/2026-02-20-marko-pollo-implementation.md`
+- Design: `docs/plans/2026-02-20-dekk-design.md`
+- Original Implementation Plan: `docs/plans/2026-02-20-dekk-implementation.md`
 - Cohesive Implementation Plan: `docs/plans/2026-02-20-cohesive-implementation.md`
 - AI Activity Journal: `docs/ai-journal.md`

--- a/.claude/agents/rex-frontend.md
+++ b/.claude/agents/rex-frontend.md
@@ -5,7 +5,7 @@ description: Frontend development specialist obsessed with clean React code, mod
 
 # Rex - Frontend Development Specialist
 
-You are Rex, the frontend development specialist for the Marko Pollo project. Your name is a quiet nod to your React expertise, but you're proficient across the entire frontend stack.
+You are Rex, the frontend development specialist for the Dekk project. Your name is a quiet nod to your React expertise, but you're proficient across the entire frontend stack.
 
 ## Personality
 
@@ -143,6 +143,6 @@ When verifying visual fidelity before declaring work complete:
 
 ## Key Documents
 
-- Design: `docs/plans/2026-02-20-marko-pollo-design.md`
-- Original Implementation Plan: `docs/plans/2026-02-20-marko-pollo-implementation.md`
+- Design: `docs/plans/2026-02-20-dekk-design.md`
+- Original Implementation Plan: `docs/plans/2026-02-20-dekk-implementation.md`
 - Cohesive Implementation Plan: `docs/plans/2026-02-20-cohesive-implementation.md`

--- a/.claude/agents/sage-security.md
+++ b/.claude/agents/sage-security.md
@@ -5,7 +5,7 @@ description: Security specialist focused on web application security, vulnerabil
 
 # Sage - Security Specialist
 
-You are Sage, the security specialist for the Marko Pollo project. Your name reflects the wisdom you bring to protecting applications and their users.
+You are Sage, the security specialist for the Dekk project. Your name reflects the wisdom you bring to protecting applications and their users.
 
 ## Personality
 
@@ -49,7 +49,7 @@ When reviewing for security:
 - [ ] Is the Mermaid rendering sandboxed (no script injection via diagram syntax)?
 - [ ] Are dependencies from reputable sources with no known CVEs?
 
-## Threat Model (Marko Pollo Specific)
+## Threat Model (Dekk Specific)
 
 1. **XSS via Markdown** - Highest risk. User-authored markdown rendered as HTML. Mitigation: rehype-sanitize, CSP
 2. **XSS via Shiki output** - Shiki generates HTML. Ensure it does not pass through unsanitized user input
@@ -102,6 +102,6 @@ When reviewing for security:
 
 ## Key Documents
 
-- Design: `docs/plans/2026-02-20-marko-pollo-design.md`
-- Original Implementation Plan: `docs/plans/2026-02-20-marko-pollo-implementation.md`
+- Design: `docs/plans/2026-02-20-dekk-design.md`
+- Original Implementation Plan: `docs/plans/2026-02-20-dekk-implementation.md`
 - Cohesive Implementation Plan: `docs/plans/2026-02-20-cohesive-implementation.md`

--- a/.claude/agents/turing-qa.md
+++ b/.claude/agents/turing-qa.md
@@ -5,7 +5,7 @@ description: QA, testing, and infrastructure expert who excels at end-to-end tes
 
 # Turing - QA, Testing & Infrastructure Expert
 
-You are Turing, the QA, testing, and infrastructure specialist for the Marko Pollo project. Named after Alan Turing, you bring mathematical rigor to testing and a deep understanding of what makes systems reliable.
+You are Turing, the QA, testing, and infrastructure specialist for the Dekk project. Named after Alan Turing, you bring mathematical rigor to testing and a deep understanding of what makes systems reliable.
 
 ## Personality
 
@@ -154,6 +154,6 @@ When reporting visual UX issues:
 
 ## Key Documents
 
-- Design: `docs/plans/2026-02-20-marko-pollo-design.md`
-- Original Implementation Plan: `docs/plans/2026-02-20-marko-pollo-implementation.md`
+- Design: `docs/plans/2026-02-20-dekk-design.md`
+- Original Implementation Plan: `docs/plans/2026-02-20-dekk-implementation.md`
 - Cohesive Implementation Plan: `docs/plans/2026-02-20-cohesive-implementation.md`

--- a/.claude/commands/create-presentation.md
+++ b/.claude/commands/create-presentation.md
@@ -3,7 +3,7 @@ description: "Create a new slide deck presentation. Use when asked to make, crea
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep
 ---
 
-Create a new Marko Pollo slide deck.
+Create a new Dekk slide deck.
 
 ## Format Reference
 

--- a/.claude/commands/implement-task.md
+++ b/.claude/commands/implement-task.md
@@ -4,7 +4,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep
 ---
 
 Implement the specified task from the implementation plans. Check both:
-- `docs/plans/2026-02-20-marko-pollo-implementation.md` (original 16-task plan, Tasks 1-16)
+- `docs/plans/2026-02-20-dekk-implementation.md` (original 16-task plan, Tasks 1-16)
 - `docs/plans/2026-02-20-cohesive-implementation.md` (cohesive feature suite, Tasks 1.1-4.8)
 
 Follow the TDD approach defined in the plan:
@@ -15,6 +15,6 @@ Follow the TDD approach defined in the plan:
 5. Run the full test suite to ensure no regressions
 6. Commit with the message specified in the plan
 
-Refer to the design doc at `docs/plans/2026-02-20-marko-pollo-design.md` for any visual or architectural details.
+Refer to the design doc at `docs/plans/2026-02-20-dekk-design.md` for any visual or architectural details.
 
 Task number to implement: $ARGUMENTS

--- a/.claude/commands/issue-close.md
+++ b/.claude/commands/issue-close.md
@@ -3,7 +3,7 @@ description: Close a GitHub issue by number with optional comment (e.g., /issue-
 allowed-tools: Bash
 ---
 
-Close a GitHub issue on the `dulvac/marko-pollo` repository.
+Close a GitHub issue on the `dulvac/dekk` repository.
 
 ## Argument Parsing
 
@@ -17,11 +17,11 @@ If no issue number is provided, ask the user for one.
 
 1. **Verify authentication**: Run `gh auth status` to confirm the active GitHub account.
 
-2. **Confirm issue exists**: Run `gh issue view <number> --repo dulvac/marko-pollo --json state,title` to verify the issue exists and is currently open. If already closed, report that and stop.
+2. **Confirm issue exists**: Run `gh issue view <number> --repo dulvac/dekk --json state,title` to verify the issue exists and is currently open. If already closed, report that and stop.
 
-3. **Add comment** (if provided): Run `gh issue comment <number> --repo dulvac/marko-pollo --body "<comment>"` before closing.
+3. **Add comment** (if provided): Run `gh issue comment <number> --repo dulvac/dekk --body "<comment>"` before closing.
 
-4. **Close the issue**: Run `gh issue close <number> --repo dulvac/marko-pollo`.
+4. **Close the issue**: Run `gh issue close <number> --repo dulvac/dekk`.
 
 5. **Report**: Output confirmation with the issue title and URL.
 

--- a/.claude/commands/issue-create.md
+++ b/.claude/commands/issue-create.md
@@ -3,7 +3,7 @@ description: Create a new GitHub issue (e.g., /issue-create "Fix button contrast
 allowed-tools: Bash
 ---
 
-Create a new GitHub issue on the `dulvac/marko-pollo` repository.
+Create a new GitHub issue on the `dulvac/dekk` repository.
 
 ## Argument Parsing
 
@@ -18,11 +18,11 @@ If no arguments are provided, ask the user for at least a title.
 
 1. **Verify authentication**: Run `gh auth status` to confirm the active GitHub account.
 
-2. **Validate labels** (if any provided): Run `gh label list --repo dulvac/marko-pollo --json name` and verify each requested label exists. Warn and skip any invalid labels.
+2. **Validate labels** (if any provided): Run `gh label list --repo dulvac/dekk --json name` and verify each requested label exists. Warn and skip any invalid labels.
 
 3. **Create the issue**: Build and run the `gh issue create` command:
    ```
-   gh issue create --repo dulvac/marko-pollo --title "<title>" [--label "<label>"] [--body "<body>"]
+   gh issue create --repo dulvac/dekk --title "<title>" [--label "<label>"] [--body "<body>"]
    ```
    - If no `--body` was provided, use `--body ""` to skip the interactive editor.
 

--- a/.claude/commands/issue-list.md
+++ b/.claude/commands/issue-list.md
@@ -3,7 +3,7 @@ description: List open GitHub issues, optionally filtered by label (e.g., /issue
 allowed-tools: Bash
 ---
 
-List open GitHub issues for the `dulvac/marko-pollo` repository.
+List open GitHub issues for the `dulvac/dekk` repository.
 
 ## Steps
 
@@ -12,11 +12,11 @@ List open GitHub issues for the `dulvac/marko-pollo` repository.
 2. **Fetch issues**:
    - If `$ARGUMENTS` is non-empty, treat it as a label filter:
      ```
-     gh issue list --repo dulvac/marko-pollo --state open --label "$ARGUMENTS" --json number,title,labels,assignees,createdAt --limit 50
+     gh issue list --repo dulvac/dekk --state open --label "$ARGUMENTS" --json number,title,labels,assignees,createdAt --limit 50
      ```
    - If `$ARGUMENTS` is empty, list all open issues:
      ```
-     gh issue list --repo dulvac/marko-pollo --state open --json number,title,labels,assignees,createdAt --limit 50
+     gh issue list --repo dulvac/dekk --state open --json number,title,labels,assignees,createdAt --limit 50
      ```
 
 3. **Format output** as a readable table with columns: `#`, `Title`, `Labels`, `Assignees`, `Created`.

--- a/.claude/commands/issue-swarm.md
+++ b/.claude/commands/issue-swarm.md
@@ -14,11 +14,11 @@ Orchestrate parallel full-team dispatch for open GitHub issues. Each issue gets 
 2. **Fetch open issues**:
    - If `$ARGUMENTS` is non-empty, filter by label:
      ```
-     gh issue list --repo dulvac/marko-pollo --state open --label "$ARGUMENTS" --json number,title,labels,body,assignees --limit 20
+     gh issue list --repo dulvac/dekk --state open --label "$ARGUMENTS" --json number,title,labels,body,assignees --limit 20
      ```
    - If `$ARGUMENTS` is empty:
      ```
-     gh issue list --repo dulvac/marko-pollo --state open --json number,title,labels,body,assignees --limit 20
+     gh issue list --repo dulvac/dekk --state open --json number,title,labels,body,assignees --limit 20
      ```
 
 3. **If zero issues found**: Report "No open issues to work on" and stop.
@@ -65,7 +65,7 @@ isolation: "worktree"
 Each team lead receives this prompt (filled with issue-specific values):
 
 ```
-You are the team lead for GitHub issue #{number} in the marko-pollo project.
+You are the team lead for GitHub issue #{number} in the dekk project.
 You are working in an isolated worktree. Your job is to coordinate a full team to resolve this issue.
 
 ## Issue
@@ -83,7 +83,7 @@ Run: `git checkout -b {branch-name}`
 You are a team lead — coordinate, don't implement. Follow these steps:
 
 ### Step 1: Understand the Issue
-Read `CLAUDE.md` for project standards and `docs/plans/2026-02-20-marko-pollo-design.md` for design specs.
+Read `CLAUDE.md` for project standards and `docs/plans/2026-02-20-dekk-design.md` for design specs.
 Analyze the issue to understand scope and which agents are needed.
 
 ### Step 2: Create Team and Tasks
@@ -125,7 +125,7 @@ Once all agents approve and tests pass:
 2. Push the branch: `git push -u origin {branch-name}`
 3. Create PR:
    ```
-   gh pr create --repo dulvac/marko-pollo --title "{conventional-commit-title}" --body "$(cat <<'PREOF'
+   gh pr create --repo dulvac/dekk --title "{conventional-commit-title}" --body "$(cat <<'PREOF'
    ## Summary
    {brief description of changes}
 

--- a/.claude/commands/review-docs.md
+++ b/.claude/commands/review-docs.md
@@ -4,8 +4,8 @@ description: Review the design document and implementation plan for completeness
 
 Review the following documents:
 
-1. `docs/plans/2026-02-20-marko-pollo-design.md` - Design specification
-2. `docs/plans/2026-02-20-marko-pollo-implementation.md` - Implementation plan
+1. `docs/plans/2026-02-20-dekk-design.md` - Design specification
+2. `docs/plans/2026-02-20-dekk-implementation.md` - Implementation plan
 
 Analyze from these perspectives:
 

--- a/.claude/commands/team-review.md
+++ b/.claude/commands/team-review.md
@@ -1,12 +1,12 @@
 ---
-description: Spin up the full Marko Pollo team to review the current state of the project
+description: Spin up the full Dekk team to review the current state of the project
 ---
 
-Assemble the Marko Pollo development team for a comprehensive review of the project's current state.
+Assemble the Dekk development team for a comprehensive review of the project's current state.
 
-**CRITICAL: Use the team infrastructure.** All agents MUST be spawned via the `Task` tool with `team_name: "marko-pollo"` and the agent's `name` parameter. Do NOT spawn standalone agents outside the team — this bypasses team visibility and violates the project workflow.
+**CRITICAL: Use the team infrastructure.** All agents MUST be spawned via the `Task` tool with `team_name: "dekk"` and the agent's `name` parameter. Do NOT spawn standalone agents outside the team — this bypasses team visibility and violates the project workflow.
 
-Spawn the following agents into the `marko-pollo` team and have each review from their specialty:
+Spawn the following agents into the `dekk` team and have each review from their specialty:
 
 1. **Ada** (Architect) - `name: "Ada"` - Review architecture, component boundaries, data flow, crash risks
 2. **Rex** (Frontend) - `name: "Rex"` - Review React patterns, component quality, CSS, visual fidelity

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         run: npm run lint
 
       - name: Build for GitHub Pages
-        run: npm run build -- --base /marko-pollo/
+        run: npm run build -- --base /dekk/
 
       - name: Run unit tests
         run: npx vitest run

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,13 +1,13 @@
-# Marko Pollo - Project Context
+# Dekk - Project Context
 
 ## What is this?
 
-Marko Pollo is a static single-page web application for presenting markdown-authored slides with a branded dark cinematic visual identity. It targets developer talks at tech conferences, meetups, and internal engineering presentations.
+Dekk is a static single-page web application for presenting markdown-authored slides with a branded dark cinematic visual identity. It targets developer talks at tech conferences, meetups, and internal engineering presentations.
 
 ## Key Documents
 
-- **Design Document:** `docs/plans/2026-02-20-marko-pollo-design.md` - Full specification including requirements, architecture, visual identity, and component tree
-- **Original Implementation Plan:** `docs/plans/2026-02-20-marko-pollo-implementation.md` - 16-task build plan (core SPA)
+- **Design Document:** `docs/plans/2026-02-20-dekk-design.md` - Full specification including requirements, architecture, visual identity, and component tree
+- **Original Implementation Plan:** `docs/plans/2026-02-20-dekk-implementation.md` - 16-task build plan (core SPA)
 - **Cohesive Implementation Plan:** `docs/plans/2026-02-20-cohesive-implementation.md` - 4-phase feature suite (deploy, multi-deck, export, persistence)
 - **AI Activity Journal:** `docs/ai-journal.md` - Chronological record of all AI-assisted development sessions, decisions, and lessons learned
 - **Team Execution Log:** `docs/team-execution-log.md` - Rolling log of last 20 team sessions with interaction summaries and Mermaid diagrams
@@ -115,4 +115,4 @@ This project uses a team of specialized agents. See `.claude/agents/` for their 
 
 See `.claude/TEAM_WORKFLOW.md` for full team delegation rules, dispatch guidelines, and anti-patterns.
 
-**Quick reference:** Team name is `marko-pollo`. Spawn agents via `Task` tool with `team_name: "marko-pollo"`. Team lead coordinates only — never implements.
+**Quick reference:** Team name is `dekk`. Spawn agents via `Task` tool with `team_name: "dekk"`. Team lead coordinates only — never implements.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Marko Pollo
+# Dekk
 
 A markdown-to-slides presentation engine with a dark cinematic visual identity, built for developer talks at tech conferences, meetups, and engineering presentations.
 
@@ -23,7 +23,7 @@ A markdown-to-slides presentation engine with a dark cinematic visual identity, 
 
 ```bash
 git clone <repo-url>
-cd marko-pollo
+cd dekk
 npm install
 npm run dev
 ```

--- a/docs/ai-journal.md
+++ b/docs/ai-journal.md
@@ -1,4 +1,4 @@
-# Marko Pollo - AI Activity Journal
+# Dekk - AI Activity Journal
 
 A record of how AI agents are used on this project. Written for humans.
 
@@ -6,7 +6,7 @@ A record of how AI agents are used on this project. Written for humans.
 
 ## 2026-02-20 — Team Formation & Design Review
 
-**What happened:** The Marko Pollo development team was established and immediately tasked with reviewing the design document and 16-task implementation plan before any code was written.
+**What happened:** The Dekk development team was established and immediately tasked with reviewing the design document and 16-task implementation plan before any code was written.
 
 **Team assembled:**
 
@@ -45,7 +45,7 @@ A record of how AI agents are used on this project. Written for humans.
 
 ## 2026-02-20 — Full Implementation of 16-Task Plan
 
-**What happened:** Complete implementation of the Marko Pollo slide presentation tool, from empty project to fully functional SPA with 37 passing tests and a clean production build. All 16 tasks from the implementation plan were executed, covering scaffolding, parsing, rendering, views, and editor.
+**What happened:** Complete implementation of the Dekk slide presentation tool, from empty project to fully functional SPA with 37 passing tests and a clean production build. All 16 tasks from the implementation plan were executed, covering scaffolding, parsing, rendering, views, and editor.
 
 **Agents involved:**
 - **Rex (frontend specialist)** — Started Phase 1, implemented Tasks 1-4 (scaffolding, CSS foundation, remark-slides plugin, markdown parser). Hit turn limit after 4 tasks.
@@ -207,10 +207,10 @@ fe35698 - feat: add remark-slides plugin, markdown parser, and slide store
 - Proper delegation of testing work to Turing
 
 **Files updated:**
-- `/Users/adulvac/work/marko-pollo/.claude/agents/rex-frontend.md`
-- `/Users/adulvac/work/marko-pollo/.claude/agents/turing-qa.md`
-- `/Users/adulvac/work/marko-pollo/CLAUDE.md`
-- `/Users/adulvac/work/marko-pollo/docs/ai-journal.md` (this entry)
+- `/Users/adulvac/work/dekk/.claude/agents/rex-frontend.md`
+- `/Users/adulvac/work/dekk/.claude/agents/turing-qa.md`
+- `/Users/adulvac/work/dekk/CLAUDE.md`
+- `/Users/adulvac/work/dekk/docs/ai-journal.md` (this entry)
 
 **No code changes in this session.** This was a process improvement and documentation update session.
 
@@ -240,7 +240,7 @@ fe35698 - feat: add remark-slides plugin, markdown parser, and slide store
 2. **Vendor chunking** — Split heavy libraries into separate chunks: `mermaid.js`, `shiki`, and `codemirror` bundles load on-demand when features are actually used.
 3. **Dynamic imports** — Parser utilities, highlighter initialization, and Mermaid configuration all use dynamic imports to defer loading until needed.
 
-**Why this works particularly well for Marko Pollo:** The application has distinct usage modes with non-overlapping dependencies:
+**Why this works particularly well for Dekk:** The application has distinct usage modes with non-overlapping dependencies:
 - **Presentation mode** — Users navigating slides don't need CodeMirror (editor) or Mermaid (until a diagram slide appears)
 - **Editor mode** — Users editing markdown don't need Shiki syntax highlighting until they insert a code block
 - **Overview mode** — Thumbnail grid doesn't need full rendering capabilities until user clicks a slide
@@ -296,7 +296,7 @@ This phase was a perfect example of the delegation pattern working as intended:
 ### Findings (10 items, rated by severity)
 
 **1. HIGH: /team-review command doesn't enforce team infrastructure**
-The command says "spawn the following agents as a team" but doesn't specify using `team_name: "marko-pollo"`. This could lead to the exact anti-pattern documented in CLAUDE.md #5 (spawning standalone agents outside the team). The command should explicitly state that all agents must be spawned via the team infrastructure.
+The command says "spawn the following agents as a team" but doesn't specify using `team_name: "dekk"`. This could lead to the exact anti-pattern documented in CLAUDE.md #5 (spawning standalone agents outside the team). The command should explicitly state that all agents must be spawned via the team infrastructure.
 
 **2. MEDIUM: CLAUDE.md at 155 lines, exceeds self-imposed 100-line guideline**
 Eliza's own constraint says "keep CLAUDE.md under 100 lines." The team workflow section (lines 74-155) adds 80+ lines. This content is genuinely valuable — it prevents real anti-patterns — but bloats context for every session. Consider extracting team workflow rules to a dedicated file (e.g., `.claude/TEAM_WORKFLOW.md`) and keeping CLAUDE.md as a concise reference.
@@ -320,7 +320,7 @@ Eliza's responsibilities include "Skills Suggestions" but no reusable skills hav
 The command restricts `allowed-tools` to Bash, Read, Write, Edit, Glob, Grep — excluding Task and SendMessage. This means an agent running `/implement-task 7` can't delegate sub-work or communicate with the team. This is intentional for focused implementation but should be documented as "single-agent mode, no team coordination."
 
 **9. LOW: Agent definitions don't reference team config location**
-Agents spawned into the team should know where to find team info (`~/.claude/teams/marko-pollo/config.json`), but their definition files don't mention this. This matters for agents that might need to discover or message other teammates.
+Agents spawned into the team should know where to find team info (`~/.claude/teams/dekk/config.json`), but their definition files don't mention this. This matters for agents that might need to discover or message other teammates.
 
 **10. LOW: Journal project structure section can go stale**
 The "AI-Native Project Structure" file tree at the bottom of this journal is a manual snapshot. If new files are added (hooks, skills, new agents), this section becomes inaccurate. Consider either removing it (since `CLAUDE.md` serves the same purpose) or marking it as "last updated: [date]."
@@ -366,7 +366,7 @@ The 1 HIGH and 5 MEDIUM findings are all addressable improvements, not fundament
 2. Specific triggers for when to check docs (not "always" — targeted to moments where stale knowledge is risky)
 3. A library checklist specific to the agent's domain
 
-**Command fix:** The `/team-review` command was updated to explicitly require `team_name: "marko-pollo"` with a CRITICAL warning, agent `name` parameters listed for each team member, and a reminder to use `TaskCreate` for tracking. This directly addresses the HIGH finding from Entry #5.
+**Command fix:** The `/team-review` command was updated to explicitly require `team_name: "dekk"` with a CRITICAL warning, agent `name` parameters listed for each team member, and a reminder to use `TaskCreate` for tracking. This directly addresses the HIGH finding from Entry #5.
 
 **Files modified (7 total):**
 - `.claude/agents/rex-frontend.md` — Added "Staying Current" section with 7 key libraries
@@ -564,7 +564,7 @@ fe0f0df test: update test fixtures for currentDeck state field
 ## AI-Native Project Structure
 
 ```
-marko-pollo/
+dekk/
 ├── CLAUDE.md                          # Project context for AI agents (~85 lines)
 ├── .claude/
 │   ├── settings.json                  # Permissions (incl. Playwright, tsc)

--- a/docs/plans/2026-02-20-cohesive-implementation.md
+++ b/docs/plans/2026-02-20-cohesive-implementation.md
@@ -1,4 +1,4 @@
-# Marko Pollo Feature Suite — Cohesive Implementation Plan
+# Dekk Feature Suite — Cohesive Implementation Plan
 
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
@@ -87,7 +87,7 @@ Append to `ci.yml` after the `build-and-test` job:
         run: npm ci
 
       - name: Build for GitHub Pages
-        run: npm run build -- --base /marko-pollo/
+        run: npm run build -- --base /dekk/
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
@@ -158,13 +158,13 @@ git commit -m "refactor: move default slides to presentations/default/slides.md"
 
 **Step 1: Create example presentations**
 
-Create 3 example decks that showcase different Marko Pollo features. Each should use frontmatter with `title` and `author`, and exercise features like code blocks, Mermaid diagrams, tables, task lists, and emoji.
+Create 3 example decks that showcase different Dekk features. Each should use frontmatter with `title` and `author`, and exercise features like code blocks, Mermaid diagrams, tables, task lists, and emoji.
 
 **`presentations/intro-to-typescript/slides.md`** — A short tech talk (5-6 slides) about TypeScript basics. Exercises: code blocks with `typescript` language, bullet lists, bold/italic.
 
 **`presentations/architecture-patterns/slides.md`** — A software architecture talk (5-6 slides). Exercises: Mermaid diagrams (flowchart, sequence), tables, nested lists.
 
-**`presentations/getting-started/slides.md`** — A Marko Pollo tutorial deck (4-5 slides) explaining how to use the app. Exercises: keyboard shortcut reference, task lists, emoji.
+**`presentations/getting-started/slides.md`** — A Dekk tutorial deck (4-5 slides) explaining how to use the app. Exercises: keyboard shortcut reference, task lists, emoji.
 
 **Step 2: Verify all decks parse correctly**
 
@@ -653,7 +653,7 @@ git commit -m "feat: add LOAD_DECK/UNLOAD_DECK actions to store"
 // Add to loader.test.ts
 describe('loadDeck', () => {
   it('returns localStorage draft when present', () => {
-    localStorage.setItem('marko-pollo-deck-my-talk', '# Draft')
+    localStorage.setItem('dekk-deck-my-talk', '# Draft')
     const result = loadDeck('my-talk')
     expect(result).toBe('# Draft')
   })
@@ -672,16 +672,16 @@ describe('loadDeck', () => {
 describe('saveDeckDraft', () => {
   it('writes to deck-specific key', () => {
     saveDeckDraft('my-talk', '# Updated')
-    expect(localStorage.getItem('marko-pollo-deck-my-talk')).toBe('# Updated')
+    expect(localStorage.getItem('dekk-deck-my-talk')).toBe('# Updated')
   })
 })
 
 describe('migration', () => {
   it('migrates old key to default deck', () => {
-    localStorage.setItem('marko-pollo-slides', '# Old Content')
+    localStorage.setItem('dekk-slides', '# Old Content')
     migrateOldStorage()
-    expect(localStorage.getItem('marko-pollo-deck-default')).toBe('# Old Content')
-    expect(localStorage.getItem('marko-pollo-slides')).toBeNull()
+    expect(localStorage.getItem('dekk-deck-default')).toBe('# Old Content')
+    expect(localStorage.getItem('dekk-slides')).toBeNull()
   })
 })
 ```
@@ -695,8 +695,8 @@ Replace the existing `loadMarkdown()` with new functions. Keep `saveToLocalStora
 ```typescript
 import { getDeck } from './deckRegistry'
 
-const DECK_KEY_PREFIX = 'marko-pollo-deck-'
-const OLD_STORAGE_KEY = 'marko-pollo-slides'
+const DECK_KEY_PREFIX = 'dekk-deck-'
+const OLD_STORAGE_KEY = 'dekk-slides'
 
 export function loadDeck(deckId: string): string | null {
   try {
@@ -805,7 +805,7 @@ export function PickerView({ entries, onSelectDeck }: PickerViewProps) {
   return (
     <div className={styles.pickerView}>
       <header className={styles.header}>
-        <h1 className={styles.logo}>marko pollo</h1>
+        <h1 className={styles.logo}>dekk</h1>
       </header>
       <div className={styles.grid}>
         {entries.map((entry) => (
@@ -949,10 +949,10 @@ The root URL now shows the Picker. Tests need to navigate to a specific deck fir
 ```typescript
 import { test, expect } from '@playwright/test'
 
-test.describe('Marko Pollo E2E', () => {
+test.describe('Dekk E2E', () => {
   test('root shows presentation picker', async ({ page }) => {
     await page.goto('/')
-    await expect(page.getByText('marko pollo')).toBeVisible()
+    await expect(page.getByText('dekk')).toBeVisible()
     // At least the default deck should appear
     await expect(page.getByRole('button')).toHaveCount.greaterThanOrEqual(1)
   })
@@ -996,7 +996,7 @@ test.describe('Marko Pollo E2E', () => {
     await page.getByRole('button').first().click()
     await expect(page).toHaveURL(/#deck\//)
     await page.goBack()
-    await expect(page.getByText('marko pollo')).toBeVisible()
+    await expect(page.getByText('dekk')).toBeVisible()
   })
 })
 ```
@@ -1392,15 +1392,15 @@ function validateWritePath(root: string, rawPath: string): string | null {
 
 export function vitePluginDevWrite(): Plugin {
   return {
-    name: 'marko-pollo-dev-write',
+    name: 'dekk-dev-write',
     apply: 'serve',
     configureServer(server) {
-      server.middlewares.use('/__marko-pollo/ping', (_req, res) => {
+      server.middlewares.use('/__dekk/ping', (_req, res) => {
         res.setHeader('Content-Type', 'application/json')
         res.end(JSON.stringify({ ok: true }))
       })
 
-      server.middlewares.use('/__marko-pollo/write-file', async (req, res) => {
+      server.middlewares.use('/__dekk/write-file', async (req, res) => {
         if (req.method !== 'POST') {
           res.statusCode = 405
           res.end('Method not allowed')
@@ -1529,19 +1529,19 @@ describe('token-store', () => {
 
   it('stores in sessionStorage by default', () => {
     setToken('ghp_test123', 'session')
-    expect(sessionStorage.getItem('marko-pollo-github-token')).toBe('ghp_test123')
-    expect(localStorage.getItem('marko-pollo-github-token')).toBeNull()
+    expect(sessionStorage.getItem('dekk-github-token')).toBe('ghp_test123')
+    expect(localStorage.getItem('dekk-github-token')).toBeNull()
   })
 
   it('stores in localStorage when opted in', () => {
     setToken('ghp_test123', 'local')
-    expect(localStorage.getItem('marko-pollo-github-token')).toBe('ghp_test123')
+    expect(localStorage.getItem('dekk-github-token')).toBe('ghp_test123')
   })
 
   it('getToken checks sessionStorage first then localStorage', () => {
-    localStorage.setItem('marko-pollo-github-token', 'ghp_local')
+    localStorage.setItem('dekk-github-token', 'ghp_local')
     expect(getToken()).toBe('ghp_local')
-    sessionStorage.setItem('marko-pollo-github-token', 'ghp_session')
+    sessionStorage.setItem('dekk-github-token', 'ghp_session')
     expect(getToken()).toBe('ghp_session')
   })
 
@@ -1724,7 +1724,7 @@ Use `page.route()` to mock GitHub API calls and dev server write endpoint. Do NO
 ```typescript
 test('dev save button triggers file write', async ({ page }) => {
   await page.goto('/#deck/default/editor')
-  await page.route('**/__marko-pollo/write-file', route =>
+  await page.route('**/__dekk/write-file', route =>
     route.fulfill({ status: 200, body: JSON.stringify({ ok: true }) })
   )
   // Click save button, verify success indicator
@@ -1773,7 +1773,7 @@ git commit -m "test: add cross-feature integration tests"
 - [ ] All E2E tests pass (`npx playwright test`)
 - [ ] Lint passes (`npm run lint`)
 - [ ] Build succeeds (`npm run build`)
-- [ ] Build with base path succeeds (`npm run build -- --base /marko-pollo/`)
+- [ ] Build with base path succeeds (`npm run build -- --base /dekk/`)
 - [ ] Dev server starts without errors (`npm run dev`)
 - [ ] PickerView shows all presentations from `presentations/` folder
 - [ ] Clicking a deck navigates to presentation view

--- a/docs/plans/2026-02-20-dekk-design.md
+++ b/docs/plans/2026-02-20-dekk-design.md
@@ -1,4 +1,4 @@
-# Marko Pollo - Design Document
+# Dekk - Design Document
 
 **Date:** 2026-02-20
 **Updated:** 2026-02-21 (post-cohesive implementation)
@@ -6,7 +6,7 @@
 
 ## Overview
 
-Marko Pollo is a static single-page web application for presenting beautiful-looking slides authored in markdown. It targets developer talks at tech conferences, meetups, and internal engineering presentations. The app provides a highly branded, dark, cinematic visual identity with custom rendering of every markdown element.
+Dekk is a static single-page web application for presenting beautiful-looking slides authored in markdown. It targets developer talks at tech conferences, meetups, and internal engineering presentations. The app provides a highly branded, dark, cinematic visual identity with custom rendering of every markdown element.
 
 ## Requirements
 
@@ -33,7 +33,7 @@ Marko Pollo is a static single-page web application for presenting beautiful-loo
 - Markdown file export via Ctrl+S / Cmd+S (File System Access API with download fallback)
 - Export button in editor toolbar
 - Environment-aware persistence:
-  - **Dev server:** Direct file write via Vite plugin (`/__marko-pollo/write-file`)
+  - **Dev server:** Direct file write via Vite plugin (`/__dekk/write-file`)
   - **GitHub Pages:** GitHub API flow — creates branch, updates file, opens pull request
   - **Unknown:** Falls back to file download
 - GitHub Personal Access Token authentication (session or local storage)
@@ -144,7 +144,7 @@ useRoute() parses window.location.hash → Route
     |
     └── { view: *, deckId } → loadDeck(deckId)
             |
-            ├── localStorage draft (marko-pollo-deck-{id}) if present
+            ├── localStorage draft (dekk-deck-{id}) if present
             └── deckRegistry entry (build-time bundled markdown)
                     |
                     v
@@ -171,7 +171,7 @@ useRoute() parses window.location.hash → Route
     v
 detectEnvironment() → 'dev' | 'github-pages' | 'unknown'
     |
-    ├── dev → POST /__marko-pollo/write-file (Vite plugin writes to disk)
+    ├── dev → POST /__dekk/write-file (Vite plugin writes to disk)
     ├── github-pages → GitHub API (branch → update file → open PR)
     └── unknown → exportMarkdown() (File System Access API / download fallback)
 ```
@@ -220,7 +220,7 @@ unified()
   .use(remarkSlides)          // custom: split on thematicBreak (---)
   .use(remarkRehype, { allowDangerousHtml: true })
   .use(rehypeShiki, {
-    theme: 'custom-marko-pollo',
+    theme: 'custom-dekk',
     transformers: [
       transformerNotationDiff(),
       transformerNotationHighlight(),
@@ -366,12 +366,12 @@ Presentations live in `presentations/*/slides.md`. Vite's `import.meta.glob` dis
 ### Per-Deck Loading Priority (highest wins)
 
 1. **Editor / file drop** — user edits in the editor or drops a `.md` file
-2. **localStorage draft** — per-deck key `marko-pollo-deck-{id}` preserves editor changes across refreshes
+2. **localStorage draft** — per-deck key `dekk-deck-{id}` preserves editor changes across refreshes
 3. **Registry entry** — build-time bundled markdown from `presentations/{id}/slides.md`
 
 ### Legacy Migration
 
-On first load, `migrateOldStorage()` moves the old single-deck key (`marko-pollo-slides`) to `marko-pollo-deck-default`.
+On first load, `migrateOldStorage()` moves the old single-deck key (`dekk-slides`) to `dekk-deck-default`.
 
 ## Slide Viewport
 
@@ -380,7 +380,7 @@ Fixed 16:9 aspect ratio (1920x1080 logical pixels). Scaled to fit the browser vi
 ## Project Structure
 
 ```
-marko-pollo/
+dekk/
 ├── index.html
 ├── package.json
 ├── tsconfig.json

--- a/docs/plans/2026-02-20-dekk-implementation.md
+++ b/docs/plans/2026-02-20-dekk-implementation.md
@@ -1,4 +1,4 @@
-# Marko Pollo Implementation Plan
+# Dekk Implementation Plan
 
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
@@ -8,7 +8,7 @@
 
 **Tech Stack:** React 18, TypeScript, Vite, unified/remark/rehype, react-markdown, Shiki (code highlighting), Mermaid.js (diagrams), CodeMirror 6 (editor), CSS Modules + custom properties.
 
-**Design doc:** `docs/plans/2026-02-20-marko-pollo-design.md`
+**Design doc:** `docs/plans/2026-02-20-dekk-design.md`
 
 ---
 
@@ -1911,7 +1911,7 @@ Create `src/core/loader.ts`:
 ```typescript
 import defaultSlides from '../assets/slides.md?raw'
 
-export const STORAGE_KEY = 'marko-pollo-slides'
+export const STORAGE_KEY = 'dekk-slides'
 
 export function saveToLocalStorage(markdown: string): void {
   try {

--- a/docs/plans/2026-02-20-github-pages-deploy-design.md
+++ b/docs/plans/2026-02-20-github-pages-deploy-design.md
@@ -2,11 +2,11 @@
 
 ## Problem
 
-Marko Pollo has no public URL. Sharing a presentation deck requires the recipient to clone the repo, install dependencies, and run `npm run dev`. There is no automated path from a merged commit to a live, accessible deployment.
+Dekk has no public URL. Sharing a presentation deck requires the recipient to clone the repo, install dependencies, and run `npm run dev`. There is no automated path from a merged commit to a live, accessible deployment.
 
 ## Goal
 
-Automatically publish Marko Pollo to GitHub Pages on every push to `main`, with full CI checks (lint, test, build) as a required gate before any deployment proceeds.
+Automatically publish Dekk to GitHub Pages on every push to `main`, with full CI checks (lint, test, build) as a required gate before any deployment proceeds.
 
 ## Requirements
 
@@ -16,7 +16,7 @@ Automatically publish Marko Pollo to GitHub Pages on every push to `main`, with 
 
 2. **CI gate** — The deploy job must `needs` the existing CI job. A failing lint, test, or build blocks deployment entirely.
 
-3. **Vite `base` configuration** — The app is served at `https://{owner}.github.io/marko-pollo/`, not at the root. Vite must be told the sub-path so asset URLs in the built HTML are correct. Local dev must continue to work at `/`.
+3. **Vite `base` configuration** — The app is served at `https://{owner}.github.io/dekk/`, not at the root. Vite must be told the sub-path so asset URLs in the built HTML are correct. Local dev must continue to work at `/`.
 
 4. **Upload and deploy via official GitHub actions** — Use `actions/upload-pages-artifact@v3` to stage the `dist/` directory and `actions/deploy-pages@v4` to deploy. Do not use third-party publishing actions.
 
@@ -52,18 +52,18 @@ Alternative considered: a separate `deploy.yml` triggered by `workflow_run: [CI]
 
 ### Vite Base Configuration
 
-The `vite.config.ts` currently has no `base` set, which defaults to `/`. On GitHub Pages, the app is served under `/marko-pollo/`, so asset references in the built `index.html` must use that prefix.
+The `vite.config.ts` currently has no `base` set, which defaults to `/`. On GitHub Pages, the app is served under `/dekk/`, so asset references in the built `index.html` must use that prefix.
 
 **Strategy:** Pass `--base` via the CLI in the deploy build step. No change to `vite.config.ts` is required for the common case; local `npm run dev` and `npm run build` remain unaffected.
 
 Deploy build command:
 ```
-tsc -b && vite build --base /marko-pollo/
+tsc -b && vite build --base /dekk/
 ```
 
 Note: if the repository is ever renamed or moved to a different Pages path, only the workflow file changes — not the source code.
 
-Vite rewrites `index.html` asset references automatically when `--base` is set. The existing `href="/vite.svg"` in `index.html` will be rewritten to `/marko-pollo/vite.svg` in the build output. Hash-based routing (`/#/`, `/#/edit`, `/#/overview`) is unaffected by the base path because hash fragments are purely client-side.
+Vite rewrites `index.html` asset references automatically when `--base` is set. The existing `href="/vite.svg"` in `index.html` will be rewritten to `/dekk/vite.svg` in the build output. Hash-based routing (`/#/`, `/#/edit`, `/#/overview`) is unaffected by the base path because hash fragments are purely client-side.
 
 ### New Files
 
@@ -145,8 +145,8 @@ jobs:
         run: npm ci
 
       - name: Build for GitHub Pages
-        run: npm run build -- --base /marko-pollo/
-        # Equivalent to: tsc -b && vite build --base /marko-pollo/
+        run: npm run build -- --base /dekk/
+        # Equivalent to: tsc -b && vite build --base /dekk/
         # Hash-based routing is unaffected by base path changes.
         # Asset filenames include content hashes (Vite default) — cache busting is automatic.
 
@@ -164,9 +164,9 @@ jobs:
 
 `npm run build` expands to `tsc -b && vite build`. To pass `--base` to `vite build` only, use:
 ```
-npm run build -- --base /marko-pollo/
+npm run build -- --base /dekk/
 ```
-The `--` separator passes trailing arguments to the underlying script. `tsc -b` runs first (no `--base` argument), then `vite build --base /marko-pollo/`.
+The `--` separator passes trailing arguments to the underlying script. `tsc -b` runs first (no `--base` argument), then `vite build --base /dekk/`.
 
 ### GitHub Pages Repository Settings
 
@@ -212,7 +212,7 @@ To configure a custom domain:
 
 Vite copies files from `public/` into `dist/` unchanged. GitHub Pages reads `CNAME` from the deployed artifact root. No workflow changes needed.
 
-When a custom domain is active, the `--base /marko-pollo/` flag must be changed to `--base /` (or omitted), since the site is at the domain root. This is the only change required.
+When a custom domain is active, the `--base /dekk/` flag must be changed to `--base /` (or omitted), since the site is at the domain root. This is the only change required.
 
 ### Preview Deployments (Deferred)
 
@@ -235,6 +235,6 @@ If preview deployments become a priority, the cleanest path is migrating the dep
 
 - **CI gate**: Push a breaking change to a PR; verify the deploy job is skipped (does not appear or is skipped in the workflow run)
 - **Deploy on merge**: Merge a trivial change to `main`; verify the deploy job runs and the Pages URL serves the app
-- **Base path**: Navigate to `https://{owner}.github.io/marko-pollo/` — the app loads, fonts render, mermaid diagrams render (requires the correct base to load vendor chunks)
-- **Hash routing**: Navigate to `https://{owner}.github.io/marko-pollo/#/edit` directly — the editor view loads (confirms hash routing is unaffected by base path)
+- **Base path**: Navigate to `https://{owner}.github.io/dekk/` — the app loads, fonts render, mermaid diagrams render (requires the correct base to load vendor chunks)
+- **Hash routing**: Navigate to `https://{owner}.github.io/dekk/#/edit` directly — the editor view loads (confirms hash routing is unaffected by base path)
 - **Asset cache busting**: Inspect built `index.html` — all `<script>` and `<link>` `src`/`href` attributes include content hashes

--- a/docs/plans/2026-02-26-color-scheme-implementation.md
+++ b/docs/plans/2026-02-26-color-scheme-implementation.md
@@ -276,7 +276,7 @@ git commit -m "feat(colors): switch Shiki theme from github-dark to vitesse-dark
 
 **Files:**
 - Modify: `CLAUDE.md:62-71` (Brand Colors table)
-- Modify: `docs/plans/2026-02-20-marko-pollo-design.md` (Visual Identity section)
+- Modify: `docs/plans/2026-02-20-dekk-design.md` (Visual Identity section)
 
 **Step 1: Update CLAUDE.md brand colors table**
 
@@ -295,12 +295,12 @@ Replace lines 62-71 with:
 
 **Step 2: Update design doc visual identity section**
 
-Find the color table in `docs/plans/2026-02-20-marko-pollo-design.md` and update it to match the new palette. Also update any text that says "purple" or "teal" to say "gold" and "green".
+Find the color table in `docs/plans/2026-02-20-dekk-design.md` and update it to match the new palette. Also update any text that says "purple" or "teal" to say "gold" and "green".
 
 **Step 3: Commit**
 
 ```
-git add CLAUDE.md docs/plans/2026-02-20-marko-pollo-design.md
+git add CLAUDE.md docs/plans/2026-02-20-dekk-design.md
 git commit -m "docs: update brand colors documentation to earth & gold palette"
 ```
 

--- a/docs/plans/2026-02-26-color-scheme-redesign.md
+++ b/docs/plans/2026-02-26-color-scheme-redesign.md
@@ -71,7 +71,7 @@ Replace `github-dark` with `vitesse-dark` — a warm, earthy syntax highlighting
 
 ### Documentation
 - `CLAUDE.md` — brand colors table
-- `docs/plans/2026-02-20-marko-pollo-design.md` — visual identity section
+- `docs/plans/2026-02-20-dekk-design.md` — visual identity section
 
 ### Tests
 - Mock objects and test assertions that reference specific color values

--- a/docs/plans/2026-02-26-fix-github-pages-deploy-design.md
+++ b/docs/plans/2026-02-26-fix-github-pages-deploy-design.md
@@ -30,7 +30,7 @@ Steps in order:
 2. **Setup Node 20** — `actions/setup-node@v4` with npm cache
 3. **Install dependencies** — `npm ci`
 4. **Lint** — `npm run lint`
-5. **Build for GitHub Pages** — `npm run build -- --base /marko-pollo/`
+5. **Build for GitHub Pages** — `npm run build -- --base /dekk/`
 6. **Run unit tests** — `npx vitest run`
 7. **Install Playwright** — `npx playwright install --with-deps chromium`
 8. **Run E2E tests** — `npx playwright test` (against `vite preview`)
@@ -81,5 +81,5 @@ Prevents overlapping deployments.
 
 ## Risks
 
-- **E2E base path:** The preview server in CI will serve at `/marko-pollo/` base path. Playwright's `baseURL` must account for this (set to `http://localhost:5173/marko-pollo/`).
+- **E2E base path:** The preview server in CI will serve at `/dekk/` base path. Playwright's `baseURL` must account for this (set to `http://localhost:5173/dekk/`).
 - **Preview server startup:** `vite preview` requires `dist/` to exist before starting. Since build runs before E2E, this is satisfied.

--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -1,9 +1,9 @@
 import { test, expect } from '@playwright/test'
 
-test.describe('Marko Pollo E2E', () => {
+test.describe('Dekk E2E', () => {
   test('root shows presentation picker', async ({ page }) => {
     await page.goto('./')
-    await expect(page.getByRole('heading', { name: 'marko pollo' })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'dekk' })).toBeVisible()
     // At least the default deck should appear
     const buttons = page.getByRole('button')
     await expect(buttons.first()).toBeVisible()
@@ -54,7 +54,7 @@ test.describe('Marko Pollo E2E', () => {
     await page.getByRole('button').first().click()
     await expect(page).toHaveURL(/#deck\//)
     await page.goBack()
-    await expect(page.getByRole('heading', { name: 'marko pollo' })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'dekk' })).toBeVisible()
   })
 
   test('Ctrl+S downloads presentation as .md', async ({ page }) => {
@@ -83,11 +83,11 @@ test.describe('Marko Pollo E2E', () => {
     await expect(page.locator('.cm-editor')).toBeVisible()
 
     // Mock the dev server write endpoint
-    await page.route('**/__marko-pollo/write-file', route =>
+    await page.route('**/__dekk/write-file', route =>
       route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ ok: true }) })
     )
     // Mock the ping endpoint to indicate dev environment
-    await page.route('**/__marko-pollo/ping', route =>
+    await page.route('**/__dekk/ping', route =>
       route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ ok: true }) })
     )
 
@@ -115,7 +115,7 @@ test.describe('Marko Pollo E2E', () => {
 
     // Verify localStorage has the draft
     const stored = await page.evaluate(() =>
-      localStorage.getItem('marko-pollo-deck-default')
+      localStorage.getItem('dekk-deck-default')
     )
     expect(stored).toContain('# Persisted Slide')
 
@@ -153,7 +153,7 @@ test.describe('Marko Pollo E2E', () => {
 
   test('picker shows all presentations from presentations/ folder', async ({ page }) => {
     await page.goto('./')
-    await expect(page.getByRole('heading', { name: 'marko pollo' })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'dekk' })).toBeVisible()
 
     // There should be at least 4 decks (default, architecture-patterns, getting-started, intro-to-typescript)
     const buttons = page.getByRole('button')

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;700&family=JetBrains+Mono:wght@300;400&display=swap" rel="stylesheet">
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://api.github.com; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'">
-    <title>Marko Pollo</title>
+    <title>Dekk</title>
   </head>
   <body>
     <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "marko-pollo",
+  "name": "dekk",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "marko-pollo",
+      "name": "dekk",
       "version": "0.0.0",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "marko-pollo",
+  "name": "dekk",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -10,12 +10,12 @@ export default defineConfig({
   workers: isCI ? 1 : undefined,
   reporter: 'list',
   use: {
-    baseURL: isCI ? 'http://localhost:5173/marko-pollo/' : 'http://localhost:5173',
+    baseURL: isCI ? 'http://localhost:5173/dekk/' : 'http://localhost:5173',
     trace: 'on-first-retry',
   },
   webServer: {
-    command: isCI ? 'npx vite preview --port 5173 --base /marko-pollo/' : 'npm run dev',
-    url: isCI ? 'http://localhost:5173/marko-pollo/' : 'http://localhost:5173',
+    command: isCI ? 'npx vite preview --port 5173 --base /dekk/' : 'npm run dev',
+    url: isCI ? 'http://localhost:5173/dekk/' : 'http://localhost:5173',
     reuseExistingServer: !isCI,
   },
   projects: [

--- a/presentations/agentic-development/slides.md
+++ b/presentations/agentic-development/slides.md
@@ -1,5 +1,5 @@
 ---
-title: "Building with Agents: The Marko Pollo Story"
+title: "Building with Agents: The Dekk Story"
 author: Andrei Dulvac
 date: 2026-02-27
 ---
@@ -10,7 +10,7 @@ The story of a project built by an AI team
 
 ---
 
-## What is Marko Pollo?
+## What is Dekk?
 
 A **static single-page application** for presenting markdown-authored slides with a branded dark cinematic visual identity.
 
@@ -300,7 +300,7 @@ Born from the button contrast bug, Eliza created a reusable `/visual-qa` skill:
 
 ## Thank You
 
-:globe_with_meridians: Built with **Marko Pollo** — a slide deck app built by its own agent team
+:globe_with_meridians: Built with **Dekk** — a slide deck app built by its own agent team
 
 :hammer_and_wrench: Powered by **Claude Code** + specialized agent definitions
 

--- a/presentations/default/slides.md
+++ b/presentations/default/slides.md
@@ -1,9 +1,9 @@
 ---
-title: Marko Pollo Demo
-author: Marko Pollo
+title: Dekk Demo
+author: Dekk
 ---
 
-# Marko Pollo :rocket:
+# Dekk :rocket:
 
 A beautiful slide deck engine for developers
 

--- a/presentations/getting-started/slides.md
+++ b/presentations/getting-started/slides.md
@@ -1,9 +1,9 @@
 ---
-title: Getting Started with Marko Pollo
-author: Marko Pollo Team
+title: Getting Started with Dekk
+author: Dekk Team
 ---
 
-# Getting Started with Marko Pollo :rocket:
+# Getting Started with Dekk :rocket:
 
 Your guide to creating beautiful developer presentations
 

--- a/src/core/loader.test.ts
+++ b/src/core/loader.test.ts
@@ -90,7 +90,7 @@ describe('loadMarkdown', () => {
 
 describe('loadDeck', () => {
   it('returns localStorage draft when present', () => {
-    localStorage.setItem('marko-pollo-deck-my-talk', '# Draft')
+    localStorage.setItem('dekk-deck-my-talk', '# Draft')
     const result = loadDeck('my-talk')
     expect(result).toBe('# Draft')
   })
@@ -103,15 +103,15 @@ describe('loadDeck', () => {
 describe('saveDeckDraft', () => {
   it('writes to deck-specific key', () => {
     saveDeckDraft('my-talk', '# Updated')
-    expect(localStorage.getItem('marko-pollo-deck-my-talk')).toBe('# Updated')
+    expect(localStorage.getItem('dekk-deck-my-talk')).toBe('# Updated')
   })
 })
 
 describe('migration', () => {
   it('migrates old key to default deck', () => {
-    localStorage.setItem('marko-pollo-slides', '# Old Content')
+    localStorage.setItem('dekk-slides', '# Old Content')
     migrateOldStorage()
-    expect(localStorage.getItem('marko-pollo-deck-default')).toBe('# Old Content')
-    expect(localStorage.getItem('marko-pollo-slides')).toBeNull()
+    expect(localStorage.getItem('dekk-deck-default')).toBe('# Old Content')
+    expect(localStorage.getItem('dekk-slides')).toBeNull()
   })
 })

--- a/src/core/loader.ts
+++ b/src/core/loader.ts
@@ -1,8 +1,8 @@
 import { getDeck } from './deckRegistry'
 
-export const STORAGE_KEY = 'marko-pollo-slides'
-const DECK_KEY_PREFIX = 'marko-pollo-deck-'
-const OLD_STORAGE_KEY = 'marko-pollo-slides'
+export const STORAGE_KEY = 'dekk-slides'
+const DECK_KEY_PREFIX = 'dekk-deck-'
+const OLD_STORAGE_KEY = 'dekk-slides'
 
 export function saveToLocalStorage(markdown: string): boolean {
   try {

--- a/src/core/persistence.test.ts
+++ b/src/core/persistence.test.ts
@@ -98,7 +98,7 @@ describe('saveToDevServer', () => {
 
     expect(result).toBe(true)
     expect(mockFetch).toHaveBeenCalledWith(
-      '/__marko-pollo/write-file',
+      '/__dekk/write-file',
       expect.objectContaining({
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -170,7 +170,7 @@ describe('saveToGitHub', () => {
     expect(mockCreateBranch).toHaveBeenCalledWith(
       'owner',
       'repo',
-      expect.stringContaining('marko-pollo-'),
+      expect.stringContaining('dekk-'),
       'def456',
       'ghp_token123'
     )
@@ -181,7 +181,7 @@ describe('saveToGitHub', () => {
       '# New Content',
       expect.stringContaining('Update presentation'),
       'abc123',
-      expect.stringContaining('marko-pollo-'),
+      expect.stringContaining('dekk-'),
       'ghp_token123'
     )
     expect(mockCreatePullRequest).toHaveBeenCalledWith(
@@ -189,7 +189,7 @@ describe('saveToGitHub', () => {
       'repo',
       expect.stringContaining('Update presentation'),
       expect.any(String),
-      expect.stringContaining('marko-pollo-'),
+      expect.stringContaining('dekk-'),
       'main',
       'ghp_token123'
     )

--- a/src/core/persistence.ts
+++ b/src/core/persistence.ts
@@ -22,7 +22,7 @@ export async function detectEnvironment(): Promise<Environment> {
   // Check if running in Vite dev server
   if (import.meta.env.DEV) {
     try {
-      const response = await fetch('/__marko-pollo/ping')
+      const response = await fetch('/__dekk/ping')
       if (response.ok) {
         cachedEnvironment = 'dev'
         return 'dev'
@@ -73,7 +73,7 @@ export function detectGitHubRepo(url: string): { owner: string; repo: string } |
 
 export async function saveToDevServer(filePath: string, content: string): Promise<boolean> {
   try {
-    const response = await fetch('/__marko-pollo/write-file', {
+    const response = await fetch('/__dekk/write-file', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ path: filePath, content }),
@@ -102,7 +102,7 @@ export async function saveToGitHub(
 
   // Step 4: Create a new branch from HEAD
   const timestamp = Date.now()
-  const branchName = `marko-pollo-${timestamp}`
+  const branchName = `dekk-${timestamp}`
   await createBranch(owner, repo, branchName, headSha, token)
 
   // Step 5: Update the file on the new branch
@@ -111,7 +111,7 @@ export async function saveToGitHub(
 
   // Step 6: Create a pull request
   const prTitle = commitMessage
-  const prBody = `Automated update from Marko Pollo editor.\n\n**File:** \`${filePath}\``
+  const prBody = `Automated update from Dekk editor.\n\n**File:** \`${filePath}\``
   const { url: prUrl } = await createPullRequest(
     owner,
     repo,

--- a/src/core/token-store.test.ts
+++ b/src/core/token-store.test.ts
@@ -13,19 +13,19 @@ describe('token-store', () => {
 
   it('stores in sessionStorage by default', () => {
     setToken('ghp_test123', 'session')
-    expect(sessionStorage.getItem('marko-pollo-github-token')).toBe('ghp_test123')
-    expect(localStorage.getItem('marko-pollo-github-token')).toBeNull()
+    expect(sessionStorage.getItem('dekk-github-token')).toBe('ghp_test123')
+    expect(localStorage.getItem('dekk-github-token')).toBeNull()
   })
 
   it('stores in localStorage when opted in', () => {
     setToken('ghp_test123', 'local')
-    expect(localStorage.getItem('marko-pollo-github-token')).toBe('ghp_test123')
+    expect(localStorage.getItem('dekk-github-token')).toBe('ghp_test123')
   })
 
   it('getToken checks sessionStorage first then localStorage', () => {
-    localStorage.setItem('marko-pollo-github-token', 'ghp_local')
+    localStorage.setItem('dekk-github-token', 'ghp_local')
     expect(getToken()).toBe('ghp_local')
-    sessionStorage.setItem('marko-pollo-github-token', 'ghp_session')
+    sessionStorage.setItem('dekk-github-token', 'ghp_session')
     expect(getToken()).toBe('ghp_session')
   })
 

--- a/src/core/token-store.ts
+++ b/src/core/token-store.ts
@@ -1,4 +1,4 @@
-const STORAGE_KEY = 'marko-pollo-github-token'
+const STORAGE_KEY = 'dekk-github-token'
 
 export function getToken(): string | null {
   try {

--- a/src/views/PickerView.tsx
+++ b/src/views/PickerView.tsx
@@ -10,7 +10,7 @@ export function PickerView({ entries, onSelectDeck }: PickerViewProps) {
   return (
     <div className={styles.pickerView}>
       <header className={styles.header}>
-        <h1 className={styles.logo}>marko pollo</h1>
+        <h1 className={styles.logo}>dekk</h1>
       </header>
       <div className={styles.grid}>
         {entries.map((entry) => (

--- a/vite-plugin-dev-write.ts
+++ b/vite-plugin-dev-write.ts
@@ -14,15 +14,15 @@ export function validateWritePath(root: string, rawPath: string): string | null 
 
 export function vitePluginDevWrite(): Plugin {
   return {
-    name: 'marko-pollo-dev-write',
+    name: 'dekk-dev-write',
     apply: 'serve',
     configureServer(server) {
-      server.middlewares.use('/__marko-pollo/ping', (_req, res) => {
+      server.middlewares.use('/__dekk/ping', (_req, res) => {
         res.setHeader('Content-Type', 'application/json')
         res.end(JSON.stringify({ ok: true }))
       })
 
-      server.middlewares.use('/__marko-pollo/write-file', async (req, res) => {
+      server.middlewares.use('/__dekk/write-file', async (req, res) => {
         if (req.method !== 'POST') {
           res.statusCode = 405
           res.end('Method not allowed')


### PR DESCRIPTION
## Summary

- Complete rebrand from "Marko Pollo" to "Dekk" across 43 files
- Renamed GitHub repo from `dulvac/marko-pollo` to `dulvac/dekk`
- Updated all localStorage keys, API endpoints, branch prefixes, CI base paths
- Renamed design doc files (`marko-pollo-design.md` → `dekk-design.md`, etc.)
- Updated all agent definitions, commands, presentations, and documentation

## Verification

- **258/258 unit tests pass** (Vitest)
- **14/14 E2E tests pass** (Playwright)
- **TypeScript build succeeds**
- **Zero remaining references** to old name in any tracked file (confirmed by full codebase grep)

## Test plan

- [x] Unit tests pass (`npx vitest run` — 258/258)
- [x] E2E tests pass (`npx playwright test` — 14/14)
- [x] Build succeeds (`npm run build`)
- [x] No old name references remain (grep sweep)
- [x] GitHub repo renamed to `dulvac/dekk`
- [x] Git remote updated
- [ ] Verify GitHub Pages deploys correctly at `/dekk/` base path after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)