### PR TITLE
fix: replace low-contrast green accent text with gold

### DIFF
--- a/src/styles/code.module.css
+++ b/src/styles/code.module.css
@@ -44,7 +44,7 @@
   background-color: var(--mp-code-bg);
   padding: 2px 8px;
   border-radius: 4px;
-  color: var(--mp-secondary);
+  color: var(--mp-primary);
 }
 
 /* Shiki transformer styles */

--- a/src/styles/editor.module.css
+++ b/src/styles/editor.module.css
@@ -95,7 +95,7 @@
 
 .prLink {
   font-size: 13px;
-  color: var(--mp-secondary);
+  color: var(--mp-primary);
   font-family: var(--mp-font-body);
   text-decoration: underline;
   cursor: pointer;

--- a/src/styles/picker.module.css
+++ b/src/styles/picker.module.css
@@ -72,6 +72,6 @@
 
 .cardMeta {
   font-size: 14px;
-  color: var(--mp-secondary);
+  color: var(--mp-primary);
   margin-top: 8px;
 }

--- a/src/styles/slides.module.css
+++ b/src/styles/slides.module.css
@@ -240,14 +240,14 @@
 /* Links */
 
 .link {
-  color: var(--mp-secondary);
+  color: var(--mp-primary);
   text-decoration: none;
   border-bottom: 1px solid transparent;
   transition: border-color var(--mp-transition-duration) var(--mp-transition-ease);
 }
 
 .link:hover {
-  border-bottom-color: var(--mp-secondary);
+  border-bottom-color: var(--mp-primary);
 }
 
 /* Strikethrough */
@@ -344,7 +344,7 @@
 
 .em {
   font-style: italic;
-  color: var(--mp-secondary);
+  color: var(--mp-primary);
 }
 
 /* Horizontal rule */


### PR DESCRIPTION
## Summary
- Replaced green accent/inline code text color (`--mp-secondary` / `#1C6331`) with gold (`--mp-primary` / `#E4C56C`) for better contrast on dark surfaces
- Green on dark green had ~1.6:1 contrast ratio; gold on dark green achieves ~6.5:1, well above WCAG AA (4.5:1)
- Preserved `--mp-secondary` variable and gradient definitions for non-text decorative uses (borders, progress bars)

### Files changed
- `src/styles/code.module.css` — inline code text color
- `src/styles/slides.module.css` — links, link hover borders, italic/emphasis text
- `src/styles/picker.module.css` — deck card metadata (slide count)
- `src/styles/editor.module.css` — PR link in editor toolbar

Closes #6

## Review
- Implemented by Rex (frontend agent)
- Architecture reviewed by Ada (consistency of CSS custom property usage)
- Tests verified by Turing (258/258 tests pass, build succeeds)

## Test plan
- [x] Unit tests pass (258/258)
- [x] Build succeeds
- [ ] Inline code text is readable on all slide backgrounds
- [ ] Accent text has sufficient contrast ratio (>4.5:1 WCAG AA)
- [ ] Links are visible and distinguishable
- [ ] Emphasis/italic text is legible

🤖 Generated with [Claude Code](https://claude.com/claude-code)