### PR TITLE
fix: correct overview slide click navigation

### DIFF
--- a/src/hooks/useDeckLoader.ts
+++ b/src/hooks/useDeckLoader.ts
@@ -17,14 +17,18 @@ export function useDeckLoader(
     migrateOldStorage()
   }, [])
 
-  // Load deck when route.deckId changes
+  // Load deck when deckId changes (or when navigating to/from picker).
+  // We intentionally exclude route.view so that switching between
+  // presentation / editor / overview for the *same* deck does NOT
+  // re-dispatch LOAD_DECK (which resets currentIndex to 0).
+  const deckId = route.view === 'picker' ? null : route.deckId
+
   useEffect(() => {
-    if (route.view === 'picker') {
+    if (deckId === null) {
       dispatch({ type: 'UNLOAD_DECK' })
       return
     }
 
-    const deckId = route.deckId
     const markdown = loadDeck(deckId)
 
     if (markdown) {
@@ -34,5 +38,5 @@ export function useDeckLoader(
       setRoute({ view: 'picker' })
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [route.view === 'picker' ? null : route.deckId, route.view])
+  }, [deckId])
 }

--- a/src/views/OverviewGrid.test.tsx
+++ b/src/views/OverviewGrid.test.tsx
@@ -151,6 +151,69 @@ describe('OverviewGrid', () => {
     expect(screen.getByText('2')).toBeInTheDocument()
   })
 
+  it('calls onSelectSlide with correct index for each slide when clicked', () => {
+    const state: SlideState = {
+      rawMarkdown: '# Slide 1\n---\n# Slide 2\n---\n# Slide 3\n---\n# Slide 4',
+      slides: [
+        { metadata: {}, rawContent: '# Slide 1' },
+        { metadata: {}, rawContent: '# Slide 2' },
+        { metadata: {}, rawContent: '# Slide 3' },
+        { metadata: {}, rawContent: '# Slide 4' },
+      ],
+      deckMetadata: {},
+      currentIndex: 0,
+      currentDeck: null,
+    }
+
+    const onSelectSlide = vi.fn()
+    const { container } = renderWithContext(
+      <OverviewGrid onSelectSlide={onSelectSlide} />,
+      state
+    )
+
+    const grid = container.querySelector('[class*="grid"]')
+    const thumbnails = Array.from(grid?.children || [])
+
+    // Click each thumbnail and verify it passes the correct 0-based index
+    thumbnails.forEach((thumb, i) => {
+      fireEvent.click(thumb as Element)
+      expect(onSelectSlide).toHaveBeenLastCalledWith(i)
+    })
+
+    expect(onSelectSlide).toHaveBeenCalledTimes(4)
+  })
+
+  it('calls onSelectSlide with correct index on Enter/Space key', () => {
+    const state: SlideState = {
+      rawMarkdown: '# Slide 1\n---\n# Slide 2\n---\n# Slide 3',
+      slides: [
+        { metadata: {}, rawContent: '# Slide 1' },
+        { metadata: {}, rawContent: '# Slide 2' },
+        { metadata: {}, rawContent: '# Slide 3' },
+      ],
+      deckMetadata: {},
+      currentIndex: 0,
+      currentDeck: null,
+    }
+
+    const onSelectSlide = vi.fn()
+    const { container } = renderWithContext(
+      <OverviewGrid onSelectSlide={onSelectSlide} />,
+      state
+    )
+
+    const grid = container.querySelector('[class*="grid"]')
+    const thumbnails = Array.from(grid?.children || [])
+
+    // Press Enter on the third slide (index 2)
+    fireEvent.keyDown(thumbnails[2] as Element, { key: 'Enter' })
+    expect(onSelectSlide).toHaveBeenLastCalledWith(2)
+
+    // Press Space on the second slide (index 1)
+    fireEvent.keyDown(thumbnails[1] as Element, { key: ' ' })
+    expect(onSelectSlide).toHaveBeenLastCalledWith(1)
+  })
+
   it('renders empty grid when no slides', () => {
     const state: SlideState = {
       rawMarkdown: '',


### PR DESCRIPTION
## Summary
- Fixed bug where clicking any slide in the overview grid always navigated to slide 1 instead of the clicked slide
- Root cause: `useDeckLoader` hook included `route.view` in its effect dependency array, causing it to re-dispatch `LOAD_DECK` (which resets `currentIndex` to 0) when switching from overview to presentation view for the same deck
- Fix: removed `route.view` from the dependency array so the deck is only reloaded when `deckId` actually changes
- Added 3 new unit tests for `useDeckLoader` verifying view transitions don't trigger unnecessary reloads
- Added 2 new unit tests for `OverviewGrid` verifying correct index propagation for all slides (click and keyboard)

Closes #7

## Test plan
- [ ] All 263 unit tests pass (`npm run test:run`)
- [ ] Build succeeds (`npm run build`)
- [ ] Clicking slide N in overview navigates to slide N (not slide 1)
- [ ] Keyboard navigation (Enter/Space) on slide N in overview navigates to slide N
- [ ] Switching between editor/overview/presentation for the same deck does not reset slide position

🤖 Generated with [Claude Code](https://claude.com/claude-code)