### PR TITLE
fix: resolve editor mode scroll, focus, wrapping, and exit issues

### DIFF
--- a/src/components/MarkdownEditor.test.ts
+++ b/src/components/MarkdownEditor.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { getSlideIndexAtPosition } from './MarkdownEditor'
+
+describe('getSlideIndexAtPosition', () => {
+  const sampleMarkdown = [
+    '---',
+    'title: Test',
+    '---',
+    '',
+    '# Slide 1',
+    'Content for slide 1',
+    '',
+    '---',
+    '',
+    '# Slide 2',
+    'Content for slide 2',
+    '',
+    '---',
+    '',
+    '# Slide 3',
+    'Content for slide 3',
+  ].join('\n')
+
+  it('returns 0 for cursor in the first slide', () => {
+    // Position in "# Slide 1" — after frontmatter
+    const fmEnd = sampleMarkdown.indexOf('\n# Slide 1') + 1
+    expect(getSlideIndexAtPosition(sampleMarkdown, fmEnd)).toBe(0)
+  })
+
+  it('returns 1 for cursor in the second slide', () => {
+    const pos = sampleMarkdown.indexOf('# Slide 2')
+    expect(getSlideIndexAtPosition(sampleMarkdown, pos)).toBe(1)
+  })
+
+  it('returns 2 for cursor in the third slide', () => {
+    const pos = sampleMarkdown.indexOf('# Slide 3')
+    expect(getSlideIndexAtPosition(sampleMarkdown, pos)).toBe(2)
+  })
+
+  it('returns 0 for cursor in the frontmatter', () => {
+    expect(getSlideIndexAtPosition(sampleMarkdown, 5)).toBe(0)
+  })
+
+  it('works with simple markdown without frontmatter', () => {
+    const simple = '# Slide 1\n---\n# Slide 2\n---\n# Slide 3'
+    const pos2 = simple.indexOf('# Slide 2')
+    const pos3 = simple.indexOf('# Slide 3')
+
+    expect(getSlideIndexAtPosition(simple, 0)).toBe(0)
+    expect(getSlideIndexAtPosition(simple, pos2)).toBe(1)
+    expect(getSlideIndexAtPosition(simple, pos3)).toBe(2)
+  })
+})

--- a/src/styles/editor.module.css
+++ b/src/styles/editor.module.css
@@ -106,9 +106,37 @@
   opacity: 0.85;
 }
 
+.closeBtn {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  background: none;
+  border: 1px solid rgba(138, 125, 90, 0.3);
+  border-radius: 4px;
+  color: var(--mp-muted);
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  transition: color 0.2s ease, border-color 0.2s ease;
+}
+
+.closeBtn:hover {
+  color: var(--mp-text);
+  border-color: rgba(138, 125, 90, 0.6);
+}
+
+.closeBtn:active {
+  color: var(--mp-primary);
+}
+
 .editorWrapper {
   flex: 1;
-  overflow: hidden;
+  min-height: 0;
+  overflow: auto;
 }
 
 .previewPane {

--- a/src/views/EditorView.test.tsx
+++ b/src/views/EditorView.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import type { ReactElement } from 'react'
 import { EditorView } from './EditorView'
 import {
@@ -8,10 +8,35 @@ import {
   type SlideState,
 } from '../core/store'
 
+const mockSetRoute = vi.fn()
+
+// Mock the route hook
+vi.mock('../core/route', () => ({
+  useRoute: () => [{ view: 'editor' as const, deckId: 'test' }, mockSetRoute],
+  hashToRoute: vi.fn(),
+  routeToHash: vi.fn(),
+}))
+
 // Mock CodeMirror since it doesn't work in jsdom
 vi.mock('../components/MarkdownEditor', () => ({
-  MarkdownEditor: ({ value }: { value: string }) => (
-    <textarea data-testid="markdown-editor" value={value} readOnly />
+  MarkdownEditor: ({
+    value,
+    onEscape,
+  }: {
+    value: string
+    onChange: (v: string) => void
+    initialSlideIndex?: number
+    onCursorSlideChange?: (i: number) => void
+    onEscape?: () => void
+  }) => (
+    <div>
+      <textarea data-testid="markdown-editor" value={value} readOnly />
+      {onEscape && (
+        <button data-testid="mock-escape" onClick={onEscape}>
+          MockEsc
+        </button>
+      )}
+    </div>
   ),
 }))
 
@@ -41,6 +66,10 @@ function renderWithContext(ui: ReactElement, state: SlideState) {
 }
 
 describe('EditorView', () => {
+  beforeEach(() => {
+    mockSetRoute.mockClear()
+  })
+
   it('renders editor and preview panes', () => {
     const state: SlideState = {
       rawMarkdown: '# Test',
@@ -119,5 +148,63 @@ describe('EditorView', () => {
     renderWithContext(<EditorView />, state)
 
     expect(screen.queryByText('/')).not.toBeInTheDocument()
+  })
+
+  it('renders close button with correct aria-label', () => {
+    const state: SlideState = {
+      rawMarkdown: '# Test',
+      slides: [{ metadata: {}, rawContent: '# Test' }],
+      deckMetadata: {},
+      currentIndex: 0,
+      currentDeck: 'test',
+    }
+
+    renderWithContext(<EditorView />, state)
+
+    const closeBtn = screen.getByRole('button', { name: /close editor/i })
+    expect(closeBtn).toBeInTheDocument()
+  })
+
+  it('navigates to presentation view when close button is clicked', () => {
+    const state: SlideState = {
+      rawMarkdown: '# Test',
+      slides: [{ metadata: {}, rawContent: '# Test' }],
+      deckMetadata: {},
+      currentIndex: 0,
+      currentDeck: 'test',
+    }
+
+    renderWithContext(<EditorView />, state)
+
+    const closeBtn = screen.getByRole('button', { name: /close editor/i })
+    fireEvent.click(closeBtn)
+
+    expect(mockSetRoute).toHaveBeenCalledWith({
+      view: 'presentation',
+      deckId: 'test',
+      slideIndex: 0,
+    })
+  })
+
+  it('calls onEscape handler from MarkdownEditor', () => {
+    const state: SlideState = {
+      rawMarkdown: '# Test',
+      slides: [{ metadata: {}, rawContent: '# Test' }],
+      deckMetadata: {},
+      currentIndex: 0,
+      currentDeck: 'test',
+    }
+
+    renderWithContext(<EditorView />, state)
+
+    // The mock editor exposes an escape button
+    const escBtn = screen.getByTestId('mock-escape')
+    fireEvent.click(escBtn)
+
+    expect(mockSetRoute).toHaveBeenCalledWith({
+      view: 'presentation',
+      deckId: 'test',
+      slideIndex: 0,
+    })
   })
 })


### PR DESCRIPTION
## Summary
- Fixed vertical scrolling in editor panel
- Editor now focuses on the correct slide section when entering from a specific slide
- Preview updates to match the slide in focus in the editor
- Added line wrapping with preserved line numbers
- Added Esc key handler and X button to exit editor mode

Closes #5

## Changes

### `src/components/MarkdownEditor.tsx`
- Added `EditorView.lineWrapping` extension for line wrapping with preserved line numbers
- Added `.cm-scroller { overflow: auto }` to the CodeMirror theme for vertical scrolling
- Added `findSlideOffset()` to compute cursor position for a given slide index
- Added `getSlideIndexAtPosition()` (exported, tested) to map cursor position to slide index
- Added `initialSlideIndex` prop to scroll to/focus the correct slide on mount
- Added `onCursorSlideChange` callback to notify parent when cursor moves to a different slide
- Added `onEscape` callback wired to a CodeMirror keymap for Escape key
- Extensions are memoized with `useMemo` and stable callback refs to prevent CodeMirror reconfigurations

### `src/views/EditorView.tsx`
- Added `useRoute()` hook to navigate back to presentation view
- Captures `currentIndex` on mount via `useRef` for initial cursor positioning
- Added `handleCursorSlideChange` to dispatch `GO_TO_SLIDE` when cursor moves between slides
- Added `handleEscape` to navigate to presentation view (preserving current slide index)
- Added close button (X) in toolbar with `aria-label="Close editor"` and `title="Close editor (Esc)"`
- Passes new props (`initialSlideIndex`, `onCursorSlideChange`, `onEscape`) to `MarkdownEditor`

### `src/styles/editor.module.css`
- Changed `.editorWrapper` from `overflow: hidden` to `overflow: auto` with `min-height: 0`
- Added `.closeBtn` styles (subtle, muted border, hover/active states, pushed right via `margin-left: auto`)

### Tests
- `src/components/MarkdownEditor.test.ts` — 5 new unit tests for `getSlideIndexAtPosition`
- `src/views/EditorView.test.tsx` — 3 new tests (close button render, close button click, escape handler) + updated mock

## Test plan
- [x] Unit tests pass (266/266)
- [x] Build succeeds
- [ ] Editor scrolls vertically
- [ ] Entering editor from slide N focuses on slide N content
- [ ] Preview updates when editor focus changes
- [ ] Lines wrap with correct line numbers
- [ ] Esc key exits editor mode
- [ ] X button exits editor mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)