### PR TITLE
fix: add orphaned subtitle color to CSS variables

### DIFF
--- a/src/styles/slides.module.css
+++ b/src/styles/slides.module.css
@@ -52,7 +52,7 @@
 .subtitle {
   font-size: var(--mp-subtitle-size);
   font-weight: 500;
-  color: #A89878;
+  color: var(--mp-subtitle);
   line-height: 1.3;
 }
 

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -8,6 +8,7 @@
   --mp-muted: #8A7D5A;
   --mp-success: #4CAF50;
   --mp-danger: #D4533B;
+  --mp-subtitle: #A89878;
   --mp-code-bg: #263029;
 
   /* Typography */


### PR DESCRIPTION
## Summary
- Add `--mp-subtitle: #A89878` CSS custom property to `src/styles/variables.css` in the Colors section
- Replace hardcoded `color: #A89878` with `color: var(--mp-subtitle)` in `src/styles/slides.module.css`
- Eliminates the only hardcoded hex color across all CSS module files

Closes #19

## Test plan
- [x] `npm run test:run` passes (280/280 tests)
- [x] `npm run build` succeeds with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)