### PR TITLE
feat: add 7-day TTL expiry to stored GitHub PAT tokens

### DIFF
--- a/src/core/token-store.test.ts
+++ b/src/core/token-store.test.ts
@@ -1,30 +1,45 @@
-import { describe, it, expect, beforeEach } from 'vitest'
-import { getToken, setToken, clearToken, hasToken } from './token-store'
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import { getToken, setToken, clearToken, hasToken, TOKEN_TTL_MS } from './token-store'
 
 describe('token-store', () => {
   beforeEach(() => {
     sessionStorage.clear()
     localStorage.clear()
+    vi.restoreAllMocks()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   it('returns null when no token stored', () => {
     expect(getToken()).toBeNull()
   })
 
-  it('stores in sessionStorage by default', () => {
+  it('stores in sessionStorage as a plain string (no TTL envelope)', () => {
     setToken('ghp_test123', 'session')
     expect(sessionStorage.getItem('dekk-github-token')).toBe('ghp_test123')
     expect(localStorage.getItem('dekk-github-token')).toBeNull()
   })
 
-  it('stores in localStorage when opted in', () => {
+  it('stores in localStorage with a JSON TTL envelope', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-02-27T00:00:00Z'))
+
     setToken('ghp_test123', 'local')
-    expect(localStorage.getItem('dekk-github-token')).toBe('ghp_test123')
+
+    const raw = localStorage.getItem('dekk-github-token')
+    expect(raw).not.toBeNull()
+
+    const parsed = JSON.parse(raw!)
+    expect(parsed.token).toBe('ghp_test123')
+    expect(parsed.savedAt).toBe(new Date('2026-02-27T00:00:00Z').getTime())
   })
 
   it('getToken checks sessionStorage first then localStorage', () => {
-    localStorage.setItem('dekk-github-token', 'ghp_local')
+    setToken('ghp_local', 'local')
     expect(getToken()).toBe('ghp_local')
+
     sessionStorage.setItem('dekk-github-token', 'ghp_session')
     expect(getToken()).toBe('ghp_session')
   })
@@ -40,5 +55,114 @@ describe('token-store', () => {
   it('hasToken returns true when token exists', () => {
     setToken('ghp_test', 'session')
     expect(hasToken()).toBe(true)
+  })
+
+  describe('TTL expiry', () => {
+    it('returns token when within TTL', () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-02-27T00:00:00Z'))
+
+      setToken('ghp_valid', 'local')
+
+      // Advance 6 days (within 7-day TTL)
+      vi.setSystemTime(new Date('2026-03-05T00:00:00Z'))
+
+      expect(getToken()).toBe('ghp_valid')
+    })
+
+    it('returns null and clears token when TTL exceeded', () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-02-27T00:00:00Z'))
+
+      setToken('ghp_expired', 'local')
+
+      // Advance 8 days (beyond 7-day TTL)
+      vi.setSystemTime(new Date('2026-03-07T00:00:00Z'))
+
+      expect(getToken()).toBeNull()
+      // Token should be cleared from localStorage
+      expect(localStorage.getItem('dekk-github-token')).toBeNull()
+    })
+
+    it('returns null exactly at TTL boundary (edge case)', () => {
+      vi.useFakeTimers()
+      const startTime = new Date('2026-02-27T00:00:00Z').getTime()
+      vi.setSystemTime(startTime)
+
+      setToken('ghp_boundary', 'local')
+
+      // Advance exactly TOKEN_TTL_MS + 1ms (just past expiry)
+      vi.setSystemTime(startTime + TOKEN_TTL_MS + 1)
+
+      expect(getToken()).toBeNull()
+    })
+
+    it('returns token exactly at TTL boundary (not yet expired)', () => {
+      vi.useFakeTimers()
+      const startTime = new Date('2026-02-27T00:00:00Z').getTime()
+      vi.setSystemTime(startTime)
+
+      setToken('ghp_boundary', 'local')
+
+      // Advance exactly TOKEN_TTL_MS (at boundary, not past)
+      vi.setSystemTime(startTime + TOKEN_TTL_MS)
+
+      expect(getToken()).toBe('ghp_boundary')
+    })
+
+    it('TOKEN_TTL_MS is 7 days', () => {
+      expect(TOKEN_TTL_MS).toBe(7 * 24 * 60 * 60 * 1000)
+    })
+  })
+
+  describe('backward compatibility', () => {
+    it('treats legacy bare-string tokens as expired and clears them', () => {
+      // Simulate a token stored by the old code (plain string, no JSON envelope)
+      localStorage.setItem('dekk-github-token', 'ghp_legacy_token')
+
+      expect(getToken()).toBeNull()
+      // Legacy token should be cleaned up
+      expect(localStorage.getItem('dekk-github-token')).toBeNull()
+    })
+
+    it('treats corrupted JSON data as expired and clears it', () => {
+      localStorage.setItem('dekk-github-token', '{"bad": "data"}')
+
+      expect(getToken()).toBeNull()
+      expect(localStorage.getItem('dekk-github-token')).toBeNull()
+    })
+
+    it('treats malformed JSON as expired and clears it', () => {
+      localStorage.setItem('dekk-github-token', '{not-json')
+
+      expect(getToken()).toBeNull()
+      expect(localStorage.getItem('dekk-github-token')).toBeNull()
+    })
+  })
+
+  describe('session tokens have no TTL', () => {
+    it('session tokens are returned regardless of time elapsed', () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+
+      setToken('ghp_session_token', 'session')
+
+      // Advance 30 days — session tokens should still work
+      vi.setSystemTime(new Date('2026-01-31T00:00:00Z'))
+
+      expect(getToken()).toBe('ghp_session_token')
+    })
+  })
+
+  it('hasToken returns false for expired localStorage token', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-02-27T00:00:00Z'))
+
+    setToken('ghp_test', 'local')
+
+    // Advance 8 days
+    vi.setSystemTime(new Date('2026-03-07T00:00:00Z'))
+
+    expect(hasToken()).toBe(false)
   })
 })

--- a/src/core/token-store.ts
+++ b/src/core/token-store.ts
@@ -1,10 +1,71 @@
 const STORAGE_KEY = 'dekk-github-token'
 
+/** Token TTL: 7 days in milliseconds */
+export const TOKEN_TTL_MS = 7 * 24 * 60 * 60 * 1000
+
+interface StoredTokenData {
+  token: string
+  savedAt: number
+}
+
+/**
+ * Parse a localStorage value into StoredTokenData.
+ * Returns null if the value is missing, malformed, or represents a legacy bare token
+ * (which is treated as expired for security).
+ */
+function parseStoredToken(raw: string | null): StoredTokenData | null {
+  if (!raw) return null
+
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    if (
+      typeof parsed === 'object' &&
+      parsed !== null &&
+      'token' in parsed &&
+      'savedAt' in parsed &&
+      typeof (parsed as StoredTokenData).token === 'string' &&
+      typeof (parsed as StoredTokenData).savedAt === 'number'
+    ) {
+      return parsed as StoredTokenData
+    }
+  } catch {
+    // Not JSON — legacy bare-string token; treat as expired
+  }
+
+  return null
+}
+
+/**
+ * Check whether a stored token has exceeded the TTL.
+ */
+function isExpired(data: StoredTokenData): boolean {
+  return Date.now() - data.savedAt > TOKEN_TTL_MS
+}
+
 export function getToken(): string | null {
   try {
+    // Session tokens are ephemeral — no TTL needed
     const sessionToken = sessionStorage.getItem(STORAGE_KEY)
     if (sessionToken) return sessionToken
-    return localStorage.getItem(STORAGE_KEY)
+
+    // localStorage tokens carry a TTL envelope
+    const raw = localStorage.getItem(STORAGE_KEY)
+    const data = parseStoredToken(raw)
+
+    if (!data) {
+      // Legacy bare-string token or corrupted data — clear it
+      if (raw !== null) {
+        localStorage.removeItem(STORAGE_KEY)
+      }
+      return null
+    }
+
+    if (isExpired(data)) {
+      localStorage.removeItem(STORAGE_KEY)
+      return null
+    }
+
+    return data.token
   } catch {
     return null
   }
@@ -15,7 +76,8 @@ export function setToken(token: string, storage: 'session' | 'local'): void {
     if (storage === 'session') {
       sessionStorage.setItem(STORAGE_KEY, token)
     } else {
-      localStorage.setItem(STORAGE_KEY, token)
+      const envelope: StoredTokenData = { token, savedAt: Date.now() }
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(envelope))
     }
   } catch {
     // Storage may be disabled


### PR DESCRIPTION
## Summary

- Wraps localStorage PAT tokens in a JSON envelope with a `savedAt` timestamp
- Adds a 7-day TTL constant (`TOKEN_TTL_MS`); expired tokens are auto-cleared on `getToken()`
- Handles backward compatibility: legacy bare-string tokens (pre-TTL) are treated as expired and removed on first access
- Session storage tokens (unchecked "Remember token") remain unaffected — they have no TTL since they clear on tab close

## Changes

- `src/core/token-store.ts` — Added `StoredTokenData` interface, `parseStoredToken()` parser, `isExpired()` check, and updated `setToken()` to write JSON envelopes for `local` storage
- `src/core/token-store.test.ts` — Expanded from 6 to 16 tests covering TTL expiry, boundary conditions, backward compatibility with legacy tokens, corrupted data handling, and session token behavior

## Test plan

- [x] All 290 existing tests pass (30 test files)
- [x] 16 token-store tests pass including new TTL tests
- [x] Build succeeds (`npm run build`)
- [x] Legacy bare-string tokens are cleared on first access
- [x] Tokens within 7-day window are returned correctly
- [x] Tokens past 7-day window are cleared and return null
- [x] Session tokens are unaffected by TTL logic
- [x] Corrupted/malformed localStorage data is handled gracefully

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)