### PR TITLE
feat: create shared brand-colors module for JS-side color references

### DIFF
--- a/src/components/MarkdownEditor.tsx
+++ b/src/components/MarkdownEditor.tsx
@@ -3,6 +3,7 @@ import { markdown } from '@codemirror/lang-markdown'
 import { EditorView, keymap } from '@codemirror/view'
 import type { ReactCodeMirrorRef } from '@uiw/react-codemirror'
 import { findSlideOffset, getSlideIndexAtPosition } from '../core/parser'
+import { BRAND, primaryAlpha } from '../core/brand-colors'
 import styles from '../styles/editor.module.css'
 
 const CodeMirror = lazy(() => import('@uiw/react-codemirror'))
@@ -10,37 +11,37 @@ const CodeMirror = lazy(() => import('@uiw/react-codemirror'))
 const editorTheme = EditorView.theme(
   {
     '&': {
-      backgroundColor: '#322D2B',
-      color: '#F0E8D8',
+      backgroundColor: BRAND.bg,
+      color: BRAND.text,
       height: '100%',
     },
     '.cm-scroller': {
       overflow: 'auto',
     },
     '.cm-content': {
-      caretColor: '#E4C56C',
+      caretColor: BRAND.primary,
       fontFamily: "'JetBrains Mono', monospace",
       fontSize: '15px',
       lineHeight: '1.6',
       padding: '24px',
     },
     '.cm-activeLine': {
-      backgroundColor: 'rgba(228, 197, 108, 0.05)',
+      backgroundColor: primaryAlpha(0.05),
     },
     '.cm-gutters': {
-      backgroundColor: '#322D2B',
-      color: '#8A7D5A',
+      backgroundColor: BRAND.bg,
+      color: BRAND.muted,
       border: 'none',
       paddingLeft: '8px',
     },
     '.cm-activeLineGutter': {
-      backgroundColor: 'rgba(228, 197, 108, 0.1)',
+      backgroundColor: primaryAlpha(0.1),
     },
     '&.cm-focused .cm-selectionBackground, ::selection': {
-      backgroundColor: 'rgba(228, 197, 108, 0.3)',
+      backgroundColor: primaryAlpha(0.3),
     },
     '.cm-cursor': {
-      borderLeftColor: '#E4C56C',
+      borderLeftColor: BRAND.primary,
       borderLeftWidth: '2px',
     },
   },

--- a/src/components/MermaidDiagram.tsx
+++ b/src/components/MermaidDiagram.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState, useId } from 'react'
+import { BRAND, MERMAID_DERIVED } from '../core/brand-colors'
 import styles from '../styles/slides.module.css'
 
 let mermaidPromise: Promise<typeof import('mermaid').default> | null = null
@@ -11,17 +12,17 @@ function initMermaid() {
         securityLevel: 'strict',
         theme: 'base',
         themeVariables: {
-          primaryColor: '#3D3425',
-          primaryTextColor: '#F0E8D8',
-          primaryBorderColor: '#E4C56C',
-          lineColor: '#8A7D5A',
-          secondaryColor: '#0C4A23',
-          secondaryBorderColor: '#1C6331',
-          tertiaryColor: '#263029',
-          background: '#2E3B30',
-          mainBkg: '#352F2A',
-          nodeBorder: '#E4C56C',
-          textColor: '#F0E8D8',
+          primaryColor: MERMAID_DERIVED.primaryColor,
+          primaryTextColor: BRAND.text,
+          primaryBorderColor: BRAND.primary,
+          lineColor: BRAND.muted,
+          secondaryColor: MERMAID_DERIVED.secondaryColor,
+          secondaryBorderColor: BRAND.secondary,
+          tertiaryColor: MERMAID_DERIVED.tertiaryColor,
+          background: BRAND.surface,
+          mainBkg: MERMAID_DERIVED.mainBkg,
+          nodeBorder: BRAND.primary,
+          textColor: BRAND.text,
           fontSize: '16px',
           fontFamily: 'Inter, system-ui, sans-serif',
         },

--- a/src/core/brand-colors.ts
+++ b/src/core/brand-colors.ts
@@ -1,0 +1,58 @@
+/**
+ * Shared brand color constants for use in JavaScript-side theming.
+ *
+ * CSS custom properties (var(--mp-*)) cannot be used in APIs that accept
+ * plain JS objects (CodeMirror's EditorView.theme(), Mermaid's themeVariables).
+ * This module provides the single source of truth so hex values are never
+ * scattered across component files.
+ *
+ * Keep these values in sync with src/styles/variables.css.
+ */
+export const BRAND = {
+  /** Page / editor background — var(--mp-bg) */
+  bg: '#322D2B',
+  /** Surface panels — var(--mp-surface) */
+  surface: '#2E3B30',
+  /** Primary accent (gold) — var(--mp-primary) */
+  primary: '#E4C56C',
+  /** Secondary accent (green) — var(--mp-secondary) */
+  secondary: '#1C6331',
+  /** Body text — var(--mp-text) */
+  text: '#F0E8D8',
+  /** De-emphasised text — var(--mp-muted) */
+  muted: '#8A7D5A',
+  /** Code block background — var(--mp-code-bg) */
+  codeBg: '#263029',
+} as const
+
+/* ------------------------------------------------------------------ */
+/*  Derived / alpha helpers                                           */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Return an rgba() string for the primary gold at a given alpha.
+ * The RGB components (228, 197, 108) correspond to BRAND.primary (#E4C56C).
+ */
+export function primaryAlpha(alpha: number): string {
+  return `rgba(228, 197, 108, ${alpha})`
+}
+
+/* ------------------------------------------------------------------ */
+/*  Mermaid-specific derived colors                                   */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Colors derived from the brand palette for Mermaid diagram theming.
+ * These are intentional darkened / shifted variants that don't exist as
+ * standalone CSS variables but are needed by Mermaid's theme engine.
+ */
+export const MERMAID_DERIVED = {
+  /** Warm dark brown for primary node fill */
+  primaryColor: '#3D3425',
+  /** Darker green for secondary node fill */
+  secondaryColor: '#0C4A23',
+  /** Dark green-grey for tertiary node fill */
+  tertiaryColor: '#263029',
+  /** Warm dark surface for main background */
+  mainBkg: '#352F2A',
+} as const


### PR DESCRIPTION
## Summary

- Created `src/core/brand-colors.ts` with a `BRAND` const object exporting all core palette colors (bg, surface, primary, secondary, text, muted, codeBg) that mirror `src/styles/variables.css`
- Added a `primaryAlpha()` helper function for generating `rgba()` strings from the primary gold at arbitrary opacity levels
- Added a `MERMAID_DERIVED` const for Mermaid-specific darkened/shifted color variants (primaryColor, secondaryColor, tertiaryColor, mainBkg)
- Updated `MarkdownEditor.tsx` to import from `brand-colors.ts`, replacing 7 hardcoded hex values and 3 inline rgba() strings
- Updated `MermaidDiagram.tsx` to import from `brand-colors.ts`, replacing all 11 hardcoded hex values in Mermaid `themeVariables`

Closes #18

## Test plan

- [x] TypeScript compiles with no errors (`tsc --noEmit`)
- [x] All 280 unit tests pass (`npm run test:run`)
- [x] Production build succeeds (`npm run build`)
- [x] Zero hardcoded hex values remain in MarkdownEditor.tsx or MermaidDiagram.tsx
- [ ] Visual verification: editor theme colors unchanged in browser
- [ ] Visual verification: Mermaid diagram colors unchanged in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)