### PR TITLE
fix: make Ctrl+S in editor use environment-aware save instead of export

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,4 +1,4 @@
 export { useDeckLoader } from './useDeckLoader'
-export { useSaveShortcut } from './useSaveShortcut'
+export { useSaveShortcut, useEditorSaveShortcut } from './useSaveShortcut'
 export { useKeyboardNavigation } from './useKeyboardNavigation'
 export { useRouteSync } from './useRouteSync'

--- a/src/hooks/useSaveShortcut.test.ts
+++ b/src/hooks/useSaveShortcut.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook } from '@testing-library/react'
-import { useSaveShortcut } from './useSaveShortcut'
+import { useSaveShortcut, useEditorSaveShortcut } from './useSaveShortcut'
 import type { Route } from '../core/route'
 import type { SlideState } from '../core/store'
 
@@ -67,6 +67,19 @@ describe('useSaveShortcut', () => {
     expect(exportMarkdown).not.toHaveBeenCalled()
   })
 
+  it('does not call exportMarkdown in editor view', async () => {
+    const { exportMarkdown } = await import('../core/exporter')
+    const state = makeState()
+    const route: Route = { view: 'editor', deckId: 'test' }
+
+    renderHook(() => useSaveShortcut(state, route))
+
+    const event = new KeyboardEvent('keydown', { key: 's', ctrlKey: true, bubbles: true, cancelable: true })
+    window.dispatchEvent(event)
+
+    expect(exportMarkdown).not.toHaveBeenCalled()
+  })
+
   it('does not call exportMarkdown when rawMarkdown is empty', async () => {
     const { exportMarkdown } = await import('../core/exporter')
     const state = makeState({ rawMarkdown: '' })
@@ -78,5 +91,64 @@ describe('useSaveShortcut', () => {
     window.dispatchEvent(event)
 
     expect(exportMarkdown).not.toHaveBeenCalled()
+  })
+})
+
+describe('useEditorSaveShortcut', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('calls onSave callback on Ctrl+S', () => {
+    const onSave = vi.fn()
+    renderHook(() => useEditorSaveShortcut(onSave))
+
+    const event = new KeyboardEvent('keydown', { key: 's', ctrlKey: true, bubbles: true, cancelable: true })
+    window.dispatchEvent(event)
+
+    expect(onSave).toHaveBeenCalledOnce()
+  })
+
+  it('calls onSave callback on Cmd+S (metaKey)', () => {
+    const onSave = vi.fn()
+    renderHook(() => useEditorSaveShortcut(onSave))
+
+    const event = new KeyboardEvent('keydown', { key: 's', metaKey: true, bubbles: true, cancelable: true })
+    window.dispatchEvent(event)
+
+    expect(onSave).toHaveBeenCalledOnce()
+  })
+
+  it('does not call onSave on plain S key', () => {
+    const onSave = vi.fn()
+    renderHook(() => useEditorSaveShortcut(onSave))
+
+    const event = new KeyboardEvent('keydown', { key: 's', bubbles: true, cancelable: true })
+    window.dispatchEvent(event)
+
+    expect(onSave).not.toHaveBeenCalled()
+  })
+
+  it('prevents default browser save behavior', () => {
+    const onSave = vi.fn()
+    renderHook(() => useEditorSaveShortcut(onSave))
+
+    const event = new KeyboardEvent('keydown', { key: 's', ctrlKey: true, bubbles: true, cancelable: true })
+    const preventDefaultSpy = vi.spyOn(event, 'preventDefault')
+    window.dispatchEvent(event)
+
+    expect(preventDefaultSpy).toHaveBeenCalled()
+  })
+
+  it('cleans up event listener on unmount', () => {
+    const onSave = vi.fn()
+    const { unmount } = renderHook(() => useEditorSaveShortcut(onSave))
+
+    unmount()
+
+    const event = new KeyboardEvent('keydown', { key: 's', ctrlKey: true, bubbles: true, cancelable: true })
+    window.dispatchEvent(event)
+
+    expect(onSave).not.toHaveBeenCalled()
   })
 })

--- a/src/hooks/useSaveShortcut.ts
+++ b/src/hooks/useSaveShortcut.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useCallback } from 'react'
 import type { Route } from '../core/route'
 import type { SlideState } from '../core/store'
 import { exportMarkdown } from '../core/exporter'
@@ -6,10 +6,14 @@ import { exportMarkdown } from '../core/exporter'
 /**
  * Global Ctrl+S / Cmd+S save shortcut.
  * Separated from the main keyboard handler so it works inside CodeMirror.
+ *
+ * In editor view, this hook is a no-op — EditorView registers its own
+ * Ctrl+S handler via useEditorSaveShortcut that delegates to
+ * environment-aware persistence (handleSave) instead of exportMarkdown.
  */
 export function useSaveShortcut(state: SlideState, route: Route): void {
   useEffect(() => {
-    if (route.view === 'picker' || !state.rawMarkdown) return
+    if (route.view === 'picker' || route.view === 'editor' || !state.rawMarkdown) return
 
     const handleSave = (e: KeyboardEvent) => {
       if ((e.ctrlKey || e.metaKey) && e.key === 's') {
@@ -20,4 +24,24 @@ export function useSaveShortcut(state: SlideState, route: Route): void {
     window.addEventListener('keydown', handleSave)
     return () => window.removeEventListener('keydown', handleSave)
   }, [state.rawMarkdown, state.deckMetadata?.title, state.currentDeck, route.view])
+}
+
+/**
+ * Editor-specific Ctrl+S / Cmd+S shortcut that delegates to the
+ * environment-aware save handler (dev server write, GitHub API PR,
+ * or file download fallback) instead of always exporting.
+ */
+export function useEditorSaveShortcut(onSave: () => void): void {
+  const stableOnSave = useCallback(onSave, [onSave])
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === 's') {
+        e.preventDefault()
+        stableOnSave()
+      }
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [stableOnSave])
 }

--- a/src/views/EditorView.tsx
+++ b/src/views/EditorView.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useState, useEffect, useRef } from 'react'
 import { useSlides, useSlideDispatch } from '../core/store'
 import { useRoute } from '../core/route'
+import { useEditorSaveShortcut } from '../hooks'
 import { MarkdownEditor } from '../components/MarkdownEditor'
 import { SlideFrame } from '../components/SlideFrame'
 import { SlideRenderer } from '../components/SlideRenderer'
@@ -168,6 +169,9 @@ export function EditorView() {
       setSaveStatus('error')
     }
   }, [environment, currentDeck, localMarkdown, deckMetadata?.title])
+
+  // Bind Ctrl+S / Cmd+S to environment-aware save (not export)
+  useEditorSaveShortcut(handleSave)
 
   const handleAuthorize = useCallback(
     (token: string, storage: 'session' | 'local') => {


### PR DESCRIPTION
## Summary

- **Fixed Ctrl+S semantic inconsistency in editor view.** Previously, Ctrl+S always triggered `exportMarkdown()` (file download dialog) even in the editor, while the Save button used environment-aware persistence (dev server write, GitHub API PR, or download fallback). Now Ctrl+S in the editor delegates to the same `handleSave` logic as the Save button.
- Added `useEditorSaveShortcut` hook that binds Ctrl+S/Cmd+S to a provided callback, used by `EditorView` to wire up environment-aware save.
- Modified `useSaveShortcut` to skip when `route.view === 'editor'`, avoiding conflict with the editor-specific handler.

Closes #17

## Test plan

- [x] Existing `useSaveShortcut` tests pass (including new test for editor view skip)
- [x] New `useEditorSaveShortcut` tests cover: Ctrl+S, Cmd+S, plain S ignored, preventDefault, cleanup on unmount
- [x] Full test suite passes (286/286)
- [x] Production build succeeds (`npm run build`)
- [ ] Manual: Open editor view, press Ctrl+S — should trigger Save button behavior (not file download)
- [ ] Manual: Open presentation view, press Ctrl+S — should still trigger file export/download

🤖 Generated with [Claude Code](https://claude.com/claude-code)