### PR TITLE
fix: Moved CLI entry point from bin/dekk.js to root dekk.js and fixed 

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -34,7 +34,7 @@ Run these steps sequentially. Stop immediately if any step fails.
 
 9. **CLI E2E tests**: `npx playwright test --project=cli` — must pass.
 
-10. **Smoke test**: `node bin/dekk.js --version` — must print current version.
+10. **Smoke test**: `node dekk.js --version` — must print current version.
 
 ## Release Steps
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           mkdir -p release
           tar -czf "release/dekk-${VERSION}.tar.gz" \
-            bin/dekk.js \
+            dekk.js \
             dist/ \
             package.json
           shasum -a 256 "release/dekk-${VERSION}.tar.gz" > "release/dekk-${VERSION}.tar.gz.sha256"

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -142,7 +142,7 @@ Examples:
 
 async function getVersion(): Promise<string> {
   const thisFile = fileURLToPath(import.meta.url)
-  const packageJsonPath = path.resolve(path.dirname(thisFile), '..', 'package.json')
+  const packageJsonPath = path.resolve(path.dirname(thisFile), 'package.json')
   const content = await readFile(packageJsonPath, 'utf-8')
   const pkg = JSON.parse(content) as { version: string }
   return pkg.version
@@ -252,7 +252,7 @@ async function handleServe(args: CliArgs): Promise<void> {
     source = new LocalSource(sourcePath)
   }
   const thisFile = fileURLToPath(import.meta.url)
-  const distDir = path.resolve(path.dirname(thisFile), '..', 'dist')
+  const distDir = path.resolve(path.dirname(thisFile), 'dist')
   const server = createServer(source, distDir, args.port)
 
   const url = `http://127.0.0.1:${args.port}`

--- a/dekk.js
+++ b/dekk.js
@@ -872,7 +872,7 @@ Examples:
   dekk --ref feature/new-talk https://github.com/org/repo`;
 async function getVersion() {
   const thisFile = fileURLToPath(import.meta.url);
-  const packageJsonPath = path2.resolve(path2.dirname(thisFile), "..", "package.json");
+  const packageJsonPath = path2.resolve(path2.dirname(thisFile), "package.json");
   const content = await readFile3(packageJsonPath, "utf-8");
   const pkg = JSON.parse(content);
   return pkg.version;
@@ -964,7 +964,7 @@ async function handleServe(args) {
     source = new LocalSource(sourcePath);
   }
   const thisFile = fileURLToPath(import.meta.url);
-  const distDir = path2.resolve(path2.dirname(thisFile), "..", "dist");
+  const distDir = path2.resolve(path2.dirname(thisFile), "dist");
   const server = createServer(source, distDir, args.port);
   const url = `http://127.0.0.1:${args.port}`;
   console.log(`Serving decks from ${args.source}`);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "type": "module",
   "bin": {
-    "dekk": "./bin/dekk.js"
+    "dekk": "./dekk.js"
   },
   "scripts": {
     "dev": "vite",
@@ -13,7 +13,7 @@
     "preview": "vite preview",
     "test": "vitest",
     "test:run": "vitest run",
-    "build:cli": "esbuild cli/index.ts --bundle --platform=node --target=node22 --outfile=bin/dekk.js --format=esm --banner:js='#!/usr/bin/env node'"
+    "build:cli": "esbuild cli/index.ts --bundle --platform=node --target=node22 --outfile=dekk.js --format=esm --banner:js='#!/usr/bin/env node'"
   },
   "dependencies": {
     "@codemirror/lang-markdown": "^6.5.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
       reuseExistingServer: !isCI,
     },
     {
-      command: 'node bin/dekk.js --port 3333 --no-open ./test-fixtures/presentations/',
+      command: 'node dekk.js --port 3333 --no-open ./test-fixtures/presentations/',
       url: 'http://127.0.0.1:3333',
       reuseExistingServer: false,
     },


### PR DESCRIPTION
## Summary

Moved CLI entry point from bin/dekk.js to root dekk.js and fixed internal path resolution to resolve Homebrew MODULE_NOT_FOUND error

Fixes #44

## Details

- **Files changed:** 6
- **Commits:** 1
- **Tests:** passed

---
*Automated by gg:autofix*