### PR TITLE
fix: Treat 404 as auth prompt for private repos when no token is store

### DIFF
--- a/cli/__tests__/cli.test.ts
+++ b/cli/__tests__/cli.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { parseArgs } from '../index'
+import { parseArgs, shouldPromptForAuth } from '../index'
 
 describe('parseArgs', () => {
   it('parses local path argument', () => {
@@ -68,5 +68,31 @@ describe('parseArgs', () => {
 
   it('errors on no arguments', () => {
     expect(() => parseArgs([])).toThrow()
+  })
+})
+
+describe('shouldPromptForAuth', () => {
+  it('returns true for 401 error regardless of token', () => {
+    expect(shouldPromptForAuth('Failed to list decks: 401', null)).toBe(true)
+    expect(shouldPromptForAuth('Failed to list decks: 401', 'ghp_token')).toBe(true)
+  })
+
+  it('returns true for 403 error regardless of token', () => {
+    expect(shouldPromptForAuth('Failed to list decks: 403', null)).toBe(true)
+    expect(shouldPromptForAuth('Failed to list decks: 403', 'ghp_token')).toBe(true)
+  })
+
+  it('returns true for 404 error when no token is stored', () => {
+    expect(shouldPromptForAuth('Failed to list decks: 404', null)).toBe(true)
+    expect(shouldPromptForAuth('Failed to list decks: 404', undefined)).toBe(true)
+  })
+
+  it('returns false for 404 error when token is present', () => {
+    expect(shouldPromptForAuth('Failed to list decks: 404', 'ghp_token')).toBe(false)
+  })
+
+  it('returns false for other errors', () => {
+    expect(shouldPromptForAuth('Failed to list decks: 500', null)).toBe(false)
+    expect(shouldPromptForAuth('Network error', null)).toBe(false)
   })
 })

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -23,6 +23,21 @@ export interface CliArgs {
   logoutHost?: string
 }
 
+/**
+ * Determine whether an API error should trigger an auth prompt.
+ * GitHub returns 404 (not 401/403) for private repos when unauthenticated,
+ * so we treat 404 as auth-required only when no token is stored.
+ */
+export function shouldPromptForAuth(errorMessage: string, token: string | null | undefined): boolean {
+  if (errorMessage.includes('401') || errorMessage.includes('403')) {
+    return true
+  }
+  if (errorMessage.includes('404') && !token) {
+    return true
+  }
+  return false
+}
+
 export function parseArgs(argv: string[]): CliArgs {
   const args: CliArgs = {
     port: 3000,
@@ -217,7 +232,7 @@ async function handleServe(args: CliArgs): Promise<void> {
       await source.listDecks()
     } catch (err) {
       const msg = err instanceof Error ? err.message : ''
-      if (msg.includes('401') || msg.includes('403')) {
+      if (shouldPromptForAuth(msg, token)) {
         console.log(`Authentication required for ${parsed.host}`)
         token = await promptForToken(parsed.host)
         await saveToken(parsed.host, token, 'cli-user')


### PR DESCRIPTION
## Summary

Treat 404 as auth prompt for private repos when no token is stored, with extracted shouldPromptForAuth helper and 5 test cases

Fixes #46

## Details

- **Files changed:** 2
- **Commits:** 1
- **Tests:** passed

---
*Automated by gg:autofix*