### PR TITLE
fix: treat 404 as auth error for private GitHub repos

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -217,7 +217,7 @@ async function handleServe(args: CliArgs): Promise<void> {
       await source.listDecks()
     } catch (err) {
       const msg = err instanceof Error ? err.message : ''
-      if (msg.includes('401') || msg.includes('403')) {
+      if (msg.includes('401') || msg.includes('403') || msg.includes('404')) {
         console.log(`Authentication required for ${parsed.host}`)
         token = await promptForToken(parsed.host)
         await saveToken(parsed.host, token, 'cli-user')


### PR DESCRIPTION
## Summary

- GitHub returns 404 (not 401/403) for private repos when unauthenticated
- Auth-retry logic now also handles 404, prompting the user for a token
- Fixes `dekk https://github.com/Adobe-AEM-Foundation/project-starfish/` returning "Failed to list decks: 404"

🤖 Generated with [Claude Code](https://claude.com/claude-code)